### PR TITLE
New specifiers, grid definitions and minor style changes

### DIFF
--- a/pkgs/hanzo-ui/blocks/components/bullet-cards-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/bullet-cards-block.tsx
@@ -19,20 +19,22 @@ const BulletCardsBlockComponent: React.FC<BlockComponentProps> = ({
   const b = block as BulletCardsBlock
   const specified = (s: string) => (containsToken(b.specifiers, s))
   
+  const noBorder = specified('no-card-border') ? 'border-0' : 'md:border'
+
   const borderclx = specified('border-muted-3') ? 
     'md:border-muted-3' 
     : 
     (specified('border-muted-1') ? 'md:border-muted-1' : 'md:border-muted-2')
 
-
   return (
     <GridBlockComponent block={{blockType: 'grid', grid: b.grid} as Block} className={className} agent={agent}>
     {b.cards.map((card, index) => (
-      <div key={index} className={cn('px-0 sm:px-4 py-1 md:py-4 md:border rounded ' + 
+      <div key={index} className={cn('px-0 sm:px-4 py-1 md:py-4 rounded ' + 
         'flex flex-row justify-start items-center not-typography text-foreground',
+        noBorder,
         borderclx
       )}>
-        <InlineIcon icon={card.icon} size={b.iconSize ?? 28} agent={agent} className='shrink-0 mr-2 w-6 md:mr-4 md:w-7 '/>
+        <InlineIcon icon={card.icon} size={b.iconSize ?? 28} agent={agent} className='shrink-0 mr-2 md:mr-4 '/>
         <p className='m-0 text-sm sm:text-base'>{card.text}</p>
       </div>
     ))}

--- a/pkgs/hanzo-ui/blocks/components/bullet-cards-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/bullet-cards-block.tsx
@@ -29,7 +29,7 @@ const BulletCardsBlockComponent: React.FC<BlockComponentProps> = ({
   return (
     <GridBlockComponent block={{blockType: 'grid', grid: b.grid} as Block} className={className} agent={agent}>
     {b.cards.map((card, index) => (
-      <div key={index} className={cn('px-0 sm:px-4 py-1 md:py-4 rounded ' + 
+      <div key={index} className={cn('px-0 sm:px-4 py-1 md:py-4 rounded-lg ' + 
         'flex flex-row justify-start items-center not-typography text-foreground',
         noBorder,
         borderclx

--- a/pkgs/hanzo-ui/blocks/components/card-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/card-block.tsx
@@ -83,7 +83,7 @@ const CardBlockComponent: React.FC<
 
   const ghost = has('ghost') // no outer padding, no borders, larger title, all left-aligned bg is same (default)
 
-  const contentclx = (has('content-left') ? 'items-start ' : 'items-center ') + contentClassName
+  const contentclx = (has('content-left') ? 'items-start ' : ' items-center ') + (has('content-top') ? '!justify-start' : '') + contentClassName
   const disabledBorder = (has('appear-disabled' ) ? ' border-muted-4' : ' border-muted-3')
   const outerBorder = ((has('no-outer-border') || ghost) ? ' border-0' : '')
   const innerBorder = (ghost ? ' border-0' : '')

--- a/pkgs/hanzo-ui/blocks/components/carte-blanche-block/index.tsx
+++ b/pkgs/hanzo-ui/blocks/components/carte-blanche-block/index.tsx
@@ -34,6 +34,13 @@ const _getClx = (specifier: string, section: CardSection): string => {
       } break
     }
   }
+  if (specifier === 'big-padding-content') {
+    switch (section) {
+      case 'content': {
+        result = 'md:p-8 lg:p-12 xl:p-16'
+      } break
+    }
+  }
   else if (specifier === 'no-inner-borders') {
     switch (section) {
       case 'header': {
@@ -71,6 +78,10 @@ const CarteBlancheBlockComponent: React.FC<
     getClx('no-inner-borders', 'header'),
   ].join(' ')
 
+  const contentclx = [
+    getClx('big-padding-content', 'content'),
+  ].join(' ')
+
   return (
     <Card className={cn('flex flex-col ', className)} >
     {b.heading && (
@@ -82,7 +93,7 @@ const CarteBlancheBlockComponent: React.FC<
       </CardHeader>
     )}
     {b.content && (
-      <CardContent className={cn('typography flex flex-col justify-center', className)}>
+      <CardContent className={cn('typography flex flex-col justify-center', contentclx, className)}>
         <Content blocks={b.content} agent={agent}/>
       </CardContent>
     )}

--- a/pkgs/hanzo-ui/blocks/components/enh-heading-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/enh-heading-block.tsx
@@ -26,29 +26,29 @@ const tagFromLevel = (level: number): ElementType => {
   switch (level) {
     case 1: {
       return 'h1'
-    } 
+    }
     case 2: {
       return 'h2'
-    } 
+    }
     case 3: {
       return 'h3'
-    } 
+    }
     case 4: {
       return 'h4'
-    } 
+    }
     case 5: {
       return 'h5'
-    } 
+    }
     case 6: {
       return 'h6'
-    } 
+    }
   }
   return 'p'
 }
 
-  // TODO Impl icon support
+// TODO Impl icon support
 const Element: React.FC<{
-  asTag: ElementType 
+  asTag: ElementType
   text: string
   icon?: Icon
   iconLeft?: boolean
@@ -60,14 +60,14 @@ const Element: React.FC<{
   iconLeft=true,
   className : elClassName=''
 }) => (
-  <Tag className={elClassName}>{text}</Tag>
-)
+    <Tag className={elClassName}>{text}</Tag>
+  )
 
 const getPositionClx = (
   specified: (s: string) => boolean,
   agent: string | undefined
 ): {
-  preheading: string 
+  preheading: string
   heading: string
   byline: string
 } => {
@@ -80,22 +80,22 @@ const getPositionClx = (
 
   let headerclx = ''
   if (agent === 'phone') {
-    headerclx = (mobileHeadingCentered || headingCentered) ? 
+    headerclx = (mobileHeadingCentered || headingCentered) ?
       'self-center text-center' : (headingRight ? 'self-end text-right' : 'self-start text-left')
   }
   else {
-    const largerclx = (headingCentered) ? 
+    const largerclx = (headingCentered) ?
       'self-center text-center' : (headingRight ? 'self-end text-right' : 'self-start text-left')
 
     if (mobileHeadingCentered) {
       headerclx = 'self-center text-center md:' + largerclx.split(' ').join(' md:')
     }
     else {
-      headerclx = largerclx 
+      headerclx = largerclx
     }
   }
 
-  const bylineclx = (bylineCentered) ? 
+  const bylineclx = (bylineCentered) ?
     'self-center' : (bylineRight ? 'self-end' : 'self-start')
 
   return {
@@ -107,88 +107,88 @@ const getPositionClx = (
 
 const EnhHeadingBlockComponent: React.FC<
   BlockComponentProps & {
-  applyTypography?: boolean
-  extraSpecifiers?: string
-}> = ({
-  block,
-  className='',
-  agent,
-  applyTypography=true,
-  extraSpecifiers=''
-}) => {
+    applyTypography?: boolean
+    extraSpecifiers?: string
+  }> = ({
+    block,
+    className='',
+    agent,
+    applyTypography=true,
+    extraSpecifiers=''
+  }) => {
 
-  if (block.blockType !== 'enh-heading') {
-    return <>enhance heading block required</>
-  }
-  const b = block as EnhHeadingBlock
-  const specified = (s: string) => (containsToken(b.specifiers + extraSpecifiers, s))
-  const preheadingHeadingFont = specified('preheading-heading-font')
-  const phFontClx = preheadingHeadingFont ? 'font-heading' : ''
+    if (block.blockType !== 'enh-heading') {
+      return <>enhance heading block required</>
+    }
+    const b = block as EnhHeadingBlock
+    const specified = (s: string) => (containsToken(b.specifiers + extraSpecifiers, s))
+    const preheadingHeadingFont = specified('preheading-heading-font')
+    const phFontClx = preheadingHeadingFont ? 'font-heading' : ''
 
-  const positionclx = getPositionClx(specified, agent)
+    const positionclx = getPositionClx(specified, agent)
 
-  const Inner: React.FC = () => {
-    const toRender = [
-      {
-        tag: (b.preheading) ? 
-          (b.preheading.level !== undefined  ? tagFromLevel(b.preheading.level) : DEFAULTS.preheading.tag) 
-          : 
-          undefined, 
-        clx: (b.preheading) ? 
-          (b.preheading.mb !== undefined ? 
-            `mb-${b.preheading.mb}` : `mb-${DEFAULTS.preheading.mb}`) + ' ' + positionclx.preheading + ' ' + phFontClx
-          : 
-          positionclx.preheading + ' ' + phFontClx,
-        text: (b.preheading) ? (b.preheading.text ) : undefined,
-      },
-      {
-        tag: (b.heading.level !== undefined ? tagFromLevel(b.heading.level) : DEFAULTS.heading.tag), 
-        clx: (b.heading.mb !== undefined ? `mb-${b.heading.mb}` : `mb-${DEFAULTS.heading.mb}`) + ' ' + positionclx.heading,
-        text: b.heading.text,
-      },
-      {
-        tag: (b.byline) ? 
-          (b.byline.level !== undefined ? tagFromLevel(b.byline.level) : DEFAULTS.byline.tag) 
-          : 
-          undefined, 
-        clx: positionclx.byline,
-        text: (b.byline) ? (b.byline.text ) : undefined,
-      },
-    ] as {
-      tag: ElementType
-      clx: string
-      text: string
-    }[]
+    const Inner: React.FC = () => {
+      const toRender = [
+        {
+          tag: (b.preheading) ?
+            (b.preheading.level !== undefined  ? tagFromLevel(b.preheading.level) : DEFAULTS.preheading.tag)
+            :
+            undefined,
+          clx: (b.preheading) ?
+            (b.preheading.mb !== undefined ?
+              `mb-${b.preheading.mb}` : `mb-${DEFAULTS.preheading.mb}`) + ' ' + positionclx.preheading + ' ' + phFontClx
+            :
+            positionclx.preheading + ' ' + phFontClx,
+          text: (b.preheading) ? (b.preheading.text ) : undefined,
+        },
+        {
+          tag: (b.heading.level !== undefined ? tagFromLevel(b.heading.level) : DEFAULTS.heading.tag),
+          clx: (b.heading.mb !== undefined ? `mb-${b.heading.mb}` : `mb-${DEFAULTS.heading.mb}`) + ' ' + positionclx.heading,
+          text: b.heading.text,
+        },
+        {
+          tag: (b.byline) ?
+            (b.byline.level !== undefined ? tagFromLevel(b.byline.level) : DEFAULTS.byline.tag)
+            :
+            undefined,
+          clx: positionclx.byline,
+          text: (b.byline) ? (b.byline.text ) : undefined,
+        },
+      ] as {
+        tag: ElementType
+        clx: string
+        text: string
+      }[]
 
-    let iconRendered = false
-    return <>
-      {toRender.map(({tag, clx, text}, index) => {
-        if (!tag) return null
-        if (b.icon && !iconRendered) {
-          iconRendered = true
+      let iconRendered = false
+      return <>
+        {toRender.map(({tag, clx, text}, index) => {
+          if (!tag) return null
+          if (b.icon && !iconRendered) {
+            iconRendered = true
+            return (
+              <div className={cn('flex flex-row items-center gap-2 sm:gap-4', clx)} key={`div-${index}`}>
+                <InlineIcon icon={b.icon} size={b.iconSize ?? 32} agent={agent}/>
+                <Element asTag={tag} text={text} />
+              </div>
+            )
+          }
           return (
-            <div className={cn('flex flex-row items-center', clx)} key={`div-${index}`}>
-              <InlineIcon icon={b.icon} size={b.iconSize ?? 32} agent={agent}/>
-              <Element asTag={tag} text={text} />
-            </div>
+            (<Element asTag={tag} text={text} className={clx} key={`el-${index}`}/>)
           )
-        }
-        return (
-          (<Element asTag={tag} text={text} className={clx} key={`el-${index}`}/>)
-        )
-      })}
-    </>
-  }
+        })}
+      </>
+    }
 
-  return applyTypography ? (
-    <ApplyTypography className={cn('flex flex-col w-full !gap-0', className)}>
-      <Inner />
-    </ApplyTypography>
-  ) : (
-    <div className={cn('flex flex-col w-full gap-0', className)}>
-      <Inner />  
-    </div>
-  )
-}
+    return applyTypography ? (
+      <ApplyTypography className={cn('flex flex-col w-full !gap-0', className)}>
+        <Inner />
+      </ApplyTypography>
+    ) : (
+      <div className={cn('flex flex-col w-full gap-0', className)}>
+        <Inner />
+      </div>
+    )
+  }
 
 export default EnhHeadingBlockComponent

--- a/pkgs/hanzo-ui/blocks/components/enh-heading-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/enh-heading-block.tsx
@@ -26,29 +26,29 @@ const tagFromLevel = (level: number): ElementType => {
   switch (level) {
     case 1: {
       return 'h1'
-    }
+    } 
     case 2: {
       return 'h2'
-    }
+    } 
     case 3: {
       return 'h3'
-    }
+    } 
     case 4: {
       return 'h4'
-    }
+    } 
     case 5: {
       return 'h5'
-    }
+    } 
     case 6: {
       return 'h6'
-    }
+    } 
   }
   return 'p'
 }
 
-// TODO Impl icon support
+  // TODO Impl icon support
 const Element: React.FC<{
-  asTag: ElementType
+  asTag: ElementType 
   text: string
   icon?: Icon
   iconLeft?: boolean
@@ -60,14 +60,14 @@ const Element: React.FC<{
   iconLeft=true,
   className : elClassName=''
 }) => (
-    <Tag className={elClassName}>{text}</Tag>
-  )
+  <Tag className={elClassName}>{text}</Tag>
+)
 
 const getPositionClx = (
   specified: (s: string) => boolean,
   agent: string | undefined
 ): {
-  preheading: string
+  preheading: string 
   heading: string
   byline: string
 } => {
@@ -80,22 +80,22 @@ const getPositionClx = (
 
   let headerclx = ''
   if (agent === 'phone') {
-    headerclx = (mobileHeadingCentered || headingCentered) ?
+    headerclx = (mobileHeadingCentered || headingCentered) ? 
       'self-center text-center' : (headingRight ? 'self-end text-right' : 'self-start text-left')
   }
   else {
-    const largerclx = (headingCentered) ?
+    const largerclx = (headingCentered) ? 
       'self-center text-center' : (headingRight ? 'self-end text-right' : 'self-start text-left')
 
     if (mobileHeadingCentered) {
       headerclx = 'self-center text-center md:' + largerclx.split(' ').join(' md:')
     }
     else {
-      headerclx = largerclx
+      headerclx = largerclx 
     }
   }
 
-  const bylineclx = (bylineCentered) ?
+  const bylineclx = (bylineCentered) ? 
     'self-center' : (bylineRight ? 'self-end' : 'self-start')
 
   return {
@@ -107,88 +107,88 @@ const getPositionClx = (
 
 const EnhHeadingBlockComponent: React.FC<
   BlockComponentProps & {
-    applyTypography?: boolean
-    extraSpecifiers?: string
-  }> = ({
-    block,
-    className='',
-    agent,
-    applyTypography=true,
-    extraSpecifiers=''
-  }) => {
+  applyTypography?: boolean
+  extraSpecifiers?: string
+}> = ({
+  block,
+  className='',
+  agent,
+  applyTypography=true,
+  extraSpecifiers=''
+}) => {
 
-    if (block.blockType !== 'enh-heading') {
-      return <>enhance heading block required</>
-    }
-    const b = block as EnhHeadingBlock
-    const specified = (s: string) => (containsToken(b.specifiers + extraSpecifiers, s))
-    const preheadingHeadingFont = specified('preheading-heading-font')
-    const phFontClx = preheadingHeadingFont ? 'font-heading' : ''
-
-    const positionclx = getPositionClx(specified, agent)
-
-    const Inner: React.FC = () => {
-      const toRender = [
-        {
-          tag: (b.preheading) ?
-            (b.preheading.level !== undefined  ? tagFromLevel(b.preheading.level) : DEFAULTS.preheading.tag)
-            :
-            undefined,
-          clx: (b.preheading) ?
-            (b.preheading.mb !== undefined ?
-              `mb-${b.preheading.mb}` : `mb-${DEFAULTS.preheading.mb}`) + ' ' + positionclx.preheading + ' ' + phFontClx
-            :
-            positionclx.preheading + ' ' + phFontClx,
-          text: (b.preheading) ? (b.preheading.text ) : undefined,
-        },
-        {
-          tag: (b.heading.level !== undefined ? tagFromLevel(b.heading.level) : DEFAULTS.heading.tag),
-          clx: (b.heading.mb !== undefined ? `mb-${b.heading.mb}` : `mb-${DEFAULTS.heading.mb}`) + ' ' + positionclx.heading,
-          text: b.heading.text,
-        },
-        {
-          tag: (b.byline) ?
-            (b.byline.level !== undefined ? tagFromLevel(b.byline.level) : DEFAULTS.byline.tag)
-            :
-            undefined,
-          clx: positionclx.byline,
-          text: (b.byline) ? (b.byline.text ) : undefined,
-        },
-      ] as {
-        tag: ElementType
-        clx: string
-        text: string
-      }[]
-
-      let iconRendered = false
-      return <>
-        {toRender.map(({tag, clx, text}, index) => {
-          if (!tag) return null
-          if (b.icon && !iconRendered) {
-            iconRendered = true
-            return (
-              <div className={cn('flex flex-row items-center gap-2 sm:gap-4', clx)} key={`div-${index}`}>
-                <InlineIcon icon={b.icon} size={b.iconSize ?? 32} agent={agent}/>
-                <Element asTag={tag} text={text} />
-              </div>
-            )
-          }
-          return (
-            (<Element asTag={tag} text={text} className={clx} key={`el-${index}`}/>)
-          )
-        })}
-      </>
-    }
-
-    return applyTypography ? (
-      <ApplyTypography className={cn('flex flex-col w-full !gap-0', className)}>
-        <Inner />
-      </ApplyTypography>
-    ) : (
-      <div className={cn('flex flex-col w-full gap-0', className)}>
-        <Inner />
-      </div>
-    )
+  if (block.blockType !== 'enh-heading') {
+    return <>enhance heading block required</>
   }
+  const b = block as EnhHeadingBlock
+  const specified = (s: string) => (containsToken(b.specifiers + extraSpecifiers, s))
+  const preheadingHeadingFont = specified('preheading-heading-font')
+  const phFontClx = preheadingHeadingFont ? 'font-heading' : ''
+
+  const positionclx = getPositionClx(specified, agent)
+
+  const Inner: React.FC = () => {
+    const toRender = [
+      {
+        tag: (b.preheading) ? 
+          (b.preheading.level !== undefined  ? tagFromLevel(b.preheading.level) : DEFAULTS.preheading.tag) 
+          : 
+          undefined, 
+        clx: (b.preheading) ? 
+          (b.preheading.mb !== undefined ? 
+            `mb-${b.preheading.mb}` : `mb-${DEFAULTS.preheading.mb}`) + ' ' + positionclx.preheading + ' ' + phFontClx
+          : 
+          positionclx.preheading + ' ' + phFontClx,
+        text: (b.preheading) ? (b.preheading.text ) : undefined,
+      },
+      {
+        tag: (b.heading.level !== undefined ? tagFromLevel(b.heading.level) : DEFAULTS.heading.tag), 
+        clx: (b.heading.mb !== undefined ? `mb-${b.heading.mb}` : `mb-${DEFAULTS.heading.mb}`) + ' ' + positionclx.heading,
+        text: b.heading.text,
+      },
+      {
+        tag: (b.byline) ? 
+          (b.byline.level !== undefined ? tagFromLevel(b.byline.level) : DEFAULTS.byline.tag) 
+          : 
+          undefined, 
+        clx: positionclx.byline,
+        text: (b.byline) ? (b.byline.text ) : undefined,
+      },
+    ] as {
+      tag: ElementType
+      clx: string
+      text: string
+    }[]
+
+    let iconRendered = false
+    return <>
+      {toRender.map(({tag, clx, text}, index) => {
+        if (!tag) return null
+        if (b.icon && !iconRendered) {
+          iconRendered = true
+          return (
+            <div className={cn('flex flex-row items-center gap-2 sm:gap-4', clx)} key={`div-${index}`}>
+              <InlineIcon icon={b.icon} size={b.iconSize ?? 32} agent={agent}/>
+              <Element asTag={tag} text={text} />
+            </div>
+          )
+        }
+        return (
+          (<Element asTag={tag} text={text} className={clx} key={`el-${index}`}/>)
+        )
+      })}
+    </>
+  }
+
+  return applyTypography ? (
+    <ApplyTypography className={cn('flex flex-col w-full !gap-0', className)}>
+      <Inner />
+    </ApplyTypography>
+  ) : (
+    <div className={cn('flex flex-col w-full gap-0', className)}>
+      <Inner />  
+    </div>
+  )
+}
 
 export default EnhHeadingBlockComponent

--- a/pkgs/hanzo-ui/blocks/components/enh-heading-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/enh-heading-block.tsx
@@ -124,6 +124,7 @@ const EnhHeadingBlockComponent: React.FC<
   const specified = (s: string) => (containsToken(b.specifiers + extraSpecifiers, s))
   const preheadingHeadingFont = specified('preheading-heading-font')
   const phFontClx = preheadingHeadingFont ? 'font-heading' : ''
+  const alignMiddleClx = specified('align-middle') ? 'my-auto' : ''
 
   const positionclx = getPositionClx(specified, agent)
 
@@ -181,11 +182,11 @@ const EnhHeadingBlockComponent: React.FC<
   }
 
   return applyTypography ? (
-    <ApplyTypography className={cn('flex flex-col w-full !gap-0', className)}>
+    <ApplyTypography className={cn('flex flex-col w-full !gap-0', className, alignMiddleClx)}>
       <Inner />
     </ApplyTypography>
   ) : (
-    <div className={cn('flex flex-col w-full gap-0', className)}>
+    <div className={cn('flex flex-col w-full gap-0', className, alignMiddleClx)}>
       <Inner />  
     </div>
   )

--- a/pkgs/hanzo-ui/blocks/components/grid-block/table-borders.mutator.ts
+++ b/pkgs/hanzo-ui/blocks/components/grid-block/table-borders.mutator.ts
@@ -39,7 +39,7 @@ const getCellClx = (
   return clx
 } 
 
-const gapClx = 'gap-0 md:gap-0 xl:gap-9'
+const gapClx = 'gap-0 md:gap-0 xl:gap-0'
 
 export default {
   getCellClx,

--- a/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
+++ b/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
@@ -30,6 +30,8 @@ const ScreenfulComponent: React.FC<{
 
   const hasBannerVideo = (): boolean => (!!b.banner && (typeof b.banner === 'object'))
 
+  const tileHeight = (agent === 'desktop') ? 'h-full ' : 'h-[100svh] '
+
   const specified = (s: string) => (containsToken(b.specifiers, s))
   const narrowGutters = specified('narrow-gutters') // eg, for a table object that is large
 
@@ -40,7 +42,7 @@ const ScreenfulComponent: React.FC<{
     //    p&m-modifiers
     // ]
   const cwclx = [
-    'z-10 min-h-screen xl:mx-auto max-w-screen-xl overflow-y-hidden ',
+    'z-10 absolute left-0 right-0  top-0 bottom-0 xl:mx-auto max-w-screen-xl overflow-y-hidden ',
       // desktop header: 80px / pt-20
       // mobile header: 44px / pt-11  
     narrowGutters ? 
@@ -52,8 +54,8 @@ const ScreenfulComponent: React.FC<{
   ]
 
   return (
-    <section className={cn(snapTile ? 'snap-start snap-always min-h-screen' : '', className)}>
-      <ApplyTypography className='w-full flex flex-row justify-center self-stretch' >
+    <section className={cn('h-[100vh]', (snapTile ? 'snap-start snap-always' : ''), className)}>
+      <ApplyTypography className={tileHeight + 'w-full flex flex-row justify-center self-stretch'} >
         <Poster banner={b.banner}>
         {hasBannerVideo() && (
           <Video 

--- a/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
+++ b/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
@@ -35,8 +35,6 @@ const ScreenfulComponent: React.FC<{
   const specified = (s: string) => (containsToken(b.specifiers, s))
   const narrowGutters = specified('narrow-gutters') // eg, for a table object that is large
 
-
-  <footer></footer>
     // content wrapper clx:
     // [
     //    positioning, 

--- a/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
+++ b/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
@@ -35,6 +35,8 @@ const ScreenfulComponent: React.FC<{
   const specified = (s: string) => (containsToken(b.specifiers, s))
   const narrowGutters = specified('narrow-gutters') // eg, for a table object that is large
 
+
+  <footer></footer>
     // content wrapper clx:
     // [
     //    positioning, 

--- a/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
+++ b/pkgs/hanzo-ui/blocks/components/screenful-block/index.tsx
@@ -30,8 +30,6 @@ const ScreenfulComponent: React.FC<{
 
   const hasBannerVideo = (): boolean => (!!b.banner && (typeof b.banner === 'object'))
 
-  const tileHeight = (agent === 'desktop') ? 'h-full ' : 'h-[100svh] '
-
   const specified = (s: string) => (containsToken(b.specifiers, s))
   const narrowGutters = specified('narrow-gutters') // eg, for a table object that is large
 
@@ -42,7 +40,7 @@ const ScreenfulComponent: React.FC<{
     //    p&m-modifiers
     // ]
   const cwclx = [
-    'z-10 absolute left-0 right-0  top-0 bottom-0 xl:mx-auto max-w-screen-xl overflow-y-hidden ',
+    'z-10 min-h-screen xl:mx-auto max-w-screen-xl overflow-y-hidden ',
       // desktop header: 80px / pt-20
       // mobile header: 44px / pt-11  
     narrowGutters ? 
@@ -54,8 +52,8 @@ const ScreenfulComponent: React.FC<{
   ]
 
   return (
-    <section className={cn('h-[100vh]', (snapTile ? 'snap-start snap-always' : ''), className)}>
-      <ApplyTypography className={tileHeight + 'w-full flex flex-row justify-center self-stretch'} >
+    <section className={cn(snapTile ? 'snap-start snap-always min-h-screen' : '', className)}>
+      <ApplyTypography className='w-full flex flex-row justify-center self-stretch' >
         <Poster banner={b.banner}>
         {hasBannerVideo() && (
           <Video 

--- a/pkgs/hanzo-ui/blocks/components/video-block.tsx
+++ b/pkgs/hanzo-ui/blocks/components/video-block.tsx
@@ -108,7 +108,7 @@ const VideoBlockComponent: React.FC<BlockComponentProps & {
       }
       return ((
         <VideoPlayer 
-          className={className} 
+          className={cn('mx-auto', className)} 
           sources={b.sources} 
           width={dim.w} 
           height={dim.h} 
@@ -125,7 +125,7 @@ const VideoBlockComponent: React.FC<BlockComponentProps & {
     <Image src={b.poster!} alt='image' width={conDim.w} height={conDim.h} className={className}/>
   ) : (
     <VideoPlayer 
-      className={className} 
+      className={cn('mx-auto', className)} 
       sources={b.sources} 
       width={conDim.w} 
       height={conDim.h} 

--- a/pkgs/hanzo-ui/blocks/def/bullet-cards-block.ts
+++ b/pkgs/hanzo-ui/blocks/def/bullet-cards-block.ts
@@ -5,6 +5,7 @@ import type { BulletItem, GridDef } from '../../types'
 interface BulletCardsBlock extends Block {
   blockType: 'bullet-cards'
     /**
+     * no-card-border
      * borders-muted-1 / borders-muted-3 
      * default: 2 
      */

--- a/pkgs/hanzo-ui/common/chat-widget.tsx
+++ b/pkgs/hanzo-ui/common/chat-widget.tsx
@@ -47,7 +47,7 @@ const ChatWidget: React.FC<{
   return (<>
     <div className={
       'fixed bottom-0 sm:bottom-20 right-0 w-full h-full ' +
-      'sm:max-w-[400px] sm:max-h-[550px] sm:px-4 z-[1001] ' +
+      'sm:max-w-[400px] sm:max-h-[550px] sm:px-4 z-[1002] ' +
       (showChatbot ? 'flex' : 'hidden')
     }>
       <Card className='flex flex-col h-full w-full'>
@@ -65,7 +65,7 @@ const ChatWidget: React.FC<{
       variant='outline'
       size='link'
       onClick={onClick}
-      className='fixed bottom-4 right-0 h-12 w-12 mx-4 rounded-full'
+      className='fixed bottom-4 right-0 h-12 w-12 mx-4 rounded-full z-[1001]'
     >
       {showChatbot ? <X /> : <LuxLogo width={24} height={24} className='mt-2' />}
     </Button>

--- a/pkgs/hanzo-ui/types/grid-def.ts
+++ b/pkgs/hanzo-ui/types/grid-def.ts
@@ -10,6 +10,15 @@ interface GridDef {
   mobile?: GridColumnSpec
 }
 
+const COMMON_GRID_1_COL = {
+  at: {
+    xs: { columns: 1, gap: 2 },
+    md: { columns: 1, gap: 3 },
+    lg: { columns: 1, gap: 6 }
+  },
+  mobile: { columns: 1, gap: 2 }
+}
+
 const COMMON_GRID_2_COL = { 
     at: { 
       xs: {columns: 1, gap: 2}, 
@@ -28,10 +37,20 @@ const COMMON_GRID_3_COL = {
   mobile: {columns: 1, gap: 2}
 } as GridDef
 
+const COMMON_GRID_4_COL = { 
+  at: { 
+    xs: {columns: 1, gap: 2}, 
+    md: {columns: 2, gap: 3}, 
+    lg: {columns: 4, gap: 6}
+  },  
+  mobile: {columns: 1, gap: 2}
+} as GridDef
 
 export {
   type GridDef as default,
   type GridColumnSpec,
+  COMMON_GRID_1_COL,
   COMMON_GRID_2_COL,
-  COMMON_GRID_3_COL
+  COMMON_GRID_3_COL,
+  COMMON_GRID_4_COL
 }

--- a/pkgs/hanzo-ui/types/index.ts
+++ b/pkgs/hanzo-ui/types/index.ts
@@ -6,7 +6,7 @@ export {
   type ButtonModalDef,
 } from './button-def'
 
-export { COMMON_GRID_2_COL, COMMON_GRID_3_COL } from './grid-def'
+export { COMMON_GRID_1_COL, COMMON_GRID_2_COL, COMMON_GRID_3_COL, COMMON_GRID_4_COL } from './grid-def'
 export type {default as GridDef, GridColumnSpec} from './grid-def'
 export type { TShirtDimensions, Dimensions } from './dimensions' 
 export type { ContactInfo, ContactInfoFields } from './contact-info'


### PR DESCRIPTION
- Added new specifier for bullet card block: 'no-card-border'
- Added new specifier for card block: 'content-top' which positions card content to the top
- Added new specifiers to carte blanche block: 'big-padding-content' and 'no-outer-borders'
- Added new specifier to enh heading block: 'align-middle', centers block vertically
- Added a gap between icon and preheading in enh heading block
- Added `mx-auto` to video to center it
- Added `COMMON_GRID_1_COL` and `COMMON_GRID_4_COL` grid definitions
- Removed gap from grid when using specifier 'style-table-borders'
