### PR TITLE
Use json as env variable for firebase admin service account

### DIFF
--- a/pkgs/hanzo-auth/lib/firebase/firebase-admin.ts
+++ b/pkgs/hanzo-auth/lib/firebase/firebase-admin.ts
@@ -9,7 +9,7 @@ export const firebaseApp =
   getApps().find((it) => it.name === 'firebase-admin-app') ||
   initializeApp(
     {
-      credential: cert(process.env.FIREBASE_ADMIN_SERVICE_ACCOUNT!),
+      credential: cert(JSON.parse(process.env.FIREBASE_ADMIN_SERVICE_ACCOUNT!)),
     },
     'firebase-admin-app'
   )


### PR DESCRIPTION
In `.env.local` you can add a variable `FIREBASE_ADMIN_SERVICE_ACCOUNT=<json_in_one_line>`

I believe this is by far the easiest solution, compared to deploying with a json file or destructuring json into multiple env variables.