### PR TITLE
feat(commerce): server-side usage-metering hook (@hanzo/commerce/metering)

### DIFF
--- a/pkg/commerce/client.ts
+++ b/pkg/commerce/client.ts
@@ -67,6 +67,29 @@ export type Balance = {
   available: number
 }
 
+/**
+ * Tier-aware balance from GET /v1/billing/tier. effectiveAvailable folds the
+ * tenant's included plan allotment (e.g. the free-tier daily credit) into the
+ * prepaid available balance — gate on this to honor included usage first.
+ */
+export type TierResponse = {
+  user: string
+  tier: {
+    name: string
+    displayName?: string
+    maxAgents?: number
+    unlimitedAgents?: boolean
+    dailyCreditsCents?: number
+    allowedModels?: string[]
+  }
+  balance: {
+    currency: string
+    prepaidAvailable: number
+    dailyRemaining: number
+    effectiveAvailable: number
+  }
+}
+
 export type Transaction = {
   id?: string
   owner?: string
@@ -360,6 +383,8 @@ export class Commerce {
       body?: unknown
       token?: string
       params?: Record<string, string>
+      /** Extra request headers, e.g. X-IAM-Org-Id for S2S calls. */
+      headers?: Record<string, string>
     },
   ): Promise<T> {
     const url = new URL(path, this.baseUrl)
@@ -376,6 +401,7 @@ export class Commerce {
     const authToken = opts?.token ?? this.token
     if (authToken) headers['Authorization'] = `Bearer ${authToken}`
     if (opts?.body) headers['Content-Type'] = 'application/json'
+    if (opts?.headers) Object.assign(headers, opts.headers)
 
     try {
       const res = await fetch(url.toString(), {
@@ -400,9 +426,9 @@ export class Commerce {
   // Balance
   // -----------------------------------------------------------------------
 
-  async getBalance(user: string, currency = 'usd', token?: string): Promise<Balance> {
+  async getBalance(user: string, currency = 'usd', token?: string, headers?: Record<string, string>): Promise<Balance> {
     return this.request<Balance>('/v1/billing/balance', {
-      params: { user, currency }, token,
+      params: { user, currency }, token, headers,
     })
   }
 
@@ -412,13 +438,25 @@ export class Commerce {
     })
   }
 
+  /**
+   * Tier-aware balance: prepaid available plus the tenant's included plan
+   * allotment (effectiveAvailable). Use this for the metering gate when you
+   * want included usage (e.g. free-tier daily credit) honored before prepaid
+   * funds are drawn down.
+   */
+  async getTier(user: string, opts?: { token?: string; headers?: Record<string, string> }): Promise<TierResponse> {
+    return this.request<TierResponse>('/v1/billing/tier', {
+      params: { user }, token: opts?.token, headers: opts?.headers,
+    })
+  }
+
   // -----------------------------------------------------------------------
   // Usage
   // -----------------------------------------------------------------------
 
-  async addUsageRecord(record: UsageRecord, token?: string): Promise<Transaction> {
+  async addUsageRecord(record: UsageRecord, token?: string, headers?: Record<string, string>): Promise<Transaction> {
     return this.request<Transaction>('/v1/billing/usage', {
-      method: 'POST', body: record, token,
+      method: 'POST', body: record, token, headers,
     })
   }
 

--- a/pkg/commerce/index.ts
+++ b/pkg/commerce/index.ts
@@ -17,6 +17,7 @@ export { Commerce, CommerceApiError, hanzoCommerce } from './client'
 export type {
   CommerceClientConfig,
   Balance,
+  TierResponse,
   Transaction,
   Subscription,
   Plan,
@@ -38,3 +39,19 @@ export type {
   Affiliate,
   CreditGrant,
 } from './client'
+
+// Server-side usage metering (the one way every product meters to commerce)
+export {
+  Metering,
+  DEFAULT_COMMERCE_URL,
+  identityFromHeaders,
+  HEADER_USER_ID,
+  HEADER_ORG_ID,
+} from './metering'
+export type {
+  MeteringConfig,
+  MeteringIdentity,
+  UsageEvent,
+  RecordResult,
+  AuthDecision,
+} from './metering'

--- a/pkg/commerce/metering.test.ts
+++ b/pkg/commerce/metering.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Contract tests for @hanzo/commerce/metering.
+ *
+ * Self-contained: mocks global fetch and asserts the exact commerce wire
+ * contract, mirroring github.com/hanzoai/go-sdk/metering's tests so the two
+ * clients gate on the identical balance source. Runnable standalone with:
+ *
+ *   npx -y -p typescript@5.9.3 -p tsx tsx pkg/commerce/metering.test.ts
+ *
+ * It uses no test-runner dependency (the package ships none); a tiny harness
+ * below prints PASS/FAIL and exits non-zero on failure.
+ */
+
+import { Metering, identityFromHeaders } from './metering'
+
+// ---- tiny assert harness ----
+let failures = 0
+let count = 0
+function test(name: string, fn: () => Promise<void> | void) {
+  count++
+  Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`ok   - ${name}`))
+    .catch((err) => {
+      failures++
+      console.error(`FAIL - ${name}\n       ${err?.message ?? err}`)
+    })
+}
+function eq(actual: unknown, expected: unknown, msg = '') {
+  if (actual !== expected) throw new Error(`${msg} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+}
+function ok(cond: boolean, msg = '') {
+  if (!cond) throw new Error(msg || 'expected true')
+}
+
+// ---- fetch mock ----
+type Captured = { url: string; method: string; headers: Record<string, string>; body: unknown }
+function mockFetch(status: number, json: unknown): { restore: () => void; last: () => Captured | null } {
+  const original = globalThis.fetch
+  let last: Captured | null = null
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const hdrs: Record<string, string> = {}
+    const h = init?.headers as Record<string, string> | undefined
+    if (h) for (const [k, v] of Object.entries(h)) hdrs[k.toLowerCase()] = v as string
+    last = {
+      url: input.toString(),
+      method: init?.method ?? 'GET',
+      headers: hdrs,
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    }
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: `HTTP ${status}`,
+      json: async () => json,
+      text: async () => JSON.stringify(json),
+    } as Response
+  }) as typeof fetch
+  return { restore: () => { globalThis.fetch = original }, last: () => last }
+}
+
+const BASE = 'http://commerce.test'
+
+test('authorize allows when available > 0 and hits the canonical contract', async () => {
+  const fx = mockFetch(200, { user: 'hanzo/alice', currency: 'usd', balance: 5000, holds: 0, available: 5000 })
+  const meter = new Metering({ baseUrl: BASE, token: 'svc-token', org: 'hanzo' })
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  fx.restore()
+
+  ok(d.allowed, 'should allow')
+  eq(d.available, 5000, 'available')
+  const c = fx.last()!
+  eq(c.method, 'GET', 'method')
+  ok(c.url.startsWith(`${BASE}/v1/billing/balance?`), `url=${c.url}`)
+  ok(c.url.includes('user=hanzo%2Falice'), `url must url-encode user: ${c.url}`)
+  ok(c.url.includes('currency=usd'), `url must carry currency: ${c.url}`)
+  eq(c.headers['authorization'], 'Bearer svc-token', 'bearer')
+  eq(c.headers['x-iam-org-id'], 'hanzo', 'org header')
+})
+
+test('authorize denies (insufficient) when available == 0', async () => {
+  const fx = mockFetch(200, { available: 0 })
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo' })
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  fx.restore()
+  ok(!d.allowed, 'should deny')
+  eq(d.reason, 'insufficient_balance', 'reason')
+})
+
+test('authorize fail-closed on commerce error (503/unavailable)', async () => {
+  const fx = mockFetch(500, { error: 'boom' })
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo' })
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  fx.restore()
+  ok(!d.allowed, 'fail-closed must deny on 500')
+  eq(d.reason, 'balance_unavailable', 'reason')
+})
+
+test('authorize fail-open allows on commerce error when configured', async () => {
+  const fx = mockFetch(503, { error: 'down' })
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo', failOpen: true })
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  fx.restore()
+  ok(d.allowed, 'fail-open must allow')
+})
+
+test('authorize not-configured allows', async () => {
+  const meter = new Metering({}) // no baseUrl
+  ok(!meter.enabled, 'enabled should be false')
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  ok(d.allowed, 'not-configured must allow')
+})
+
+test('tier-aware authorize uses effectiveAvailable and hits /v1/billing/tier', async () => {
+  const fx = mockFetch(200, { user: 'hanzo/alice', tier: { name: 'free' }, balance: { currency: 'usd', prepaidAvailable: 0, dailyRemaining: 100, effectiveAvailable: 100 } })
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo', tierAware: true })
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  fx.restore()
+  ok(d.allowed, 'included allotment should allow')
+  eq(d.available, 100, 'effective available')
+  ok(fx.last()!.url.startsWith(`${BASE}/v1/billing/tier?`), `tier url=${fx.last()!.url}`)
+})
+
+test('tier-aware authorize denies when effectiveAvailable == 0', async () => {
+  const fx = mockFetch(200, { balance: { effectiveAvailable: 0, prepaidAvailable: 0, dailyRemaining: 0, currency: 'usd' } })
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo', tierAware: true })
+  const d = await meter.authorize({ user: 'hanzo/alice' })
+  fx.restore()
+  ok(!d.allowed && d.reason === 'insufficient_balance', 'exhausted must deny insufficient')
+})
+
+test('per-call org overrides default', async () => {
+  const fx = mockFetch(200, { available: 1 })
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo' })
+  await meter.authorize({ user: 'zoo/bob', org: 'zoo' })
+  fx.restore()
+  eq(fx.last()!.headers['x-iam-org-id'], 'zoo', 'per-call org override')
+})
+
+test('record posts canonical payload', async () => {
+  const fx = mockFetch(201, { transactionId: 'tx_123', user: 'hanzo/alice', amount: 250, currency: 'usd', type: 'withdraw' })
+  const meter = new Metering({ baseUrl: BASE, token: 'svc-token', org: 'hanzo' })
+  const res = await meter.record({ user: 'hanzo/alice', amount: 250, provider: 'search', requestId: 'req-9', status: 'success' })
+  fx.restore()
+
+  ok(res !== null && res.transactionId === 'tx_123' && res.amount === 250, 'record result')
+  const c = fx.last()!
+  eq(c.method, 'POST', 'method')
+  eq(c.url, `${BASE}/v1/billing/usage`, 'usage url')
+  eq(c.headers['authorization'], 'Bearer svc-token', 'bearer')
+  eq(c.headers['x-iam-org-id'], 'hanzo', 'org header')
+  const b = c.body as Record<string, unknown>
+  eq(b.user, 'hanzo/alice', 'body.user')
+  eq(b.amount, 250, 'body.amount')
+  eq(b.currency, 'usd', 'body.currency defaulted')
+  eq(b.provider, 'search', 'body.provider')
+  eq(b.requestId, 'req-9', 'body.requestId')
+  ok(!('org' in b), 'org must not leak into the body')
+})
+
+test('record zero-amount is a no-op (no fetch)', async () => {
+  const fx = mockFetch(200, {})
+  const meter = new Metering({ baseUrl: BASE, token: 't', org: 'hanzo' })
+  const res = await meter.record({ user: 'hanzo/alice', amount: 0 })
+  fx.restore()
+  ok(res === null, 'zero-amount returns null')
+  ok(fx.last() === null, 'zero-amount must not call commerce')
+})
+
+test('record not-configured is a no-op', async () => {
+  const meter = new Metering({})
+  const res = await meter.record({ user: 'hanzo/alice', amount: 100 })
+  ok(res === null, 'not-configured returns null')
+})
+
+test('fromEnv applies defaults and reads KMS-sourced token', () => {
+  const meter = Metering.fromEnv({ COMMERCE_SERVICE_TOKEN: 'kms-token', METERING_TIER_AWARE: 'true' })
+  ok(meter.enabled, 'fromEnv default base URL enables the meter')
+})
+
+test('fromEnv honors METERING_DISABLED', () => {
+  const meter = Metering.fromEnv({ METERING_DISABLED: 'true', COMMERCE_URL: BASE })
+  ok(!meter.enabled, 'disabled must not be enabled')
+})
+
+test('identityFromHeaders builds org/sub from gateway headers', () => {
+  const id = identityFromHeaders({ 'x-org-id': 'zoo', 'x-user-id': 'bob' })
+  eq(id.user, 'zoo/bob', 'user')
+  eq(id.org, 'zoo', 'org')
+})
+
+// summary
+setTimeout(() => {
+  if (failures > 0) {
+    console.error(`\n${failures}/${count} tests FAILED`)
+    process.exit(1)
+  }
+  console.log(`\nall ${count} tests passed`)
+}, 200)

--- a/pkg/commerce/metering.ts
+++ b/pkg/commerce/metering.ts
@@ -1,0 +1,289 @@
+/**
+ * @hanzo/commerce/metering
+ *
+ * The ONE way every Hanzo product meters usage to commerce — the single
+ * billing source of truth — so that everything (not only the LLM/cloud path)
+ * can be paid for. This is the TypeScript counterpart of
+ * github.com/hanzoai/go-sdk/metering; the two share an identical wire contract.
+ *
+ * It provides two operations against commerce's canonical billing API:
+ *
+ *   - authorize(): a pre-request balance gate. Fail-closed by default — if the
+ *     balance cannot be determined the request is denied, exactly like the
+ *     gateway's prepaid-balance gate. With tierAware it consults the effective
+ *     balance (prepaid + included plan allotment, e.g. the free-tier daily
+ *     credit) so included usage is honored before prepaid funds.
+ *
+ *   - record(): a post-request usage write that debits the user's balance.
+ *
+ * Composition over duplication: this wraps the existing {@link Commerce}
+ * client (GET /v1/billing/balance, GET /v1/billing/tier, POST /v1/billing/usage)
+ * rather than re-implementing the HTTP layer.
+ *
+ * Auth is the commerce service token (admin-scoped S2S), sent as
+ * `Authorization: Bearer <token>` plus the tenant org as `X-IAM-Org-Id`. The
+ * token is a secret and MUST come from KMS (the operator wires it into
+ * COMMERCE_SERVICE_TOKEN); this module never reads it from disk.
+ *
+ * @example
+ * ```ts
+ * import { Metering } from '@hanzo/commerce/metering'
+ *
+ * const meter = Metering.fromEnv()  // COMMERCE_URL + COMMERCE_SERVICE_TOKEN (KMS) + COMMERCE_SERVICE_ORG
+ *
+ * // Pre-request gate (fail-closed).
+ * const gate = await meter.authorize({ user: 'hanzo/alice' })
+ * if (!gate.allowed) {
+ *   res.status(gate.reason === 'insufficient_balance' ? 402 : 503).end()
+ *   return
+ * }
+ *
+ * // ... do the work, compute cost ...
+ *
+ * // Post-request record (best-effort).
+ * await meter.record({ user: 'hanzo/alice', amount: 5, provider: 'search' })
+ * ```
+ */
+
+import { Commerce, CommerceApiError } from './client'
+
+/** Canonical in-cluster commerce address (matches the gateway default). */
+export const DEFAULT_COMMERCE_URL = 'http://commerce.hanzo.svc.cluster.local:8001'
+
+export type MeteringConfig = {
+  /**
+   * Commerce base URL (no /v1 suffix). When empty the meter is in
+   * "not configured" mode: authorize allows and record is a no-op.
+   */
+  baseUrl?: string
+  /** Commerce service token (admin-scoped S2S). MUST be KMS-sourced. */
+  token?: string
+  /** Default tenant org slug sent as X-IAM-Org-Id (default "hanzo"). */
+  org?: string
+  /**
+   * Gate on the tier-aware effective balance (prepaid + included plan
+   * allotment) instead of the bare prepaid balance. Default false.
+   */
+  tierAware?: boolean
+  /**
+   * Allow-on-error. Default false (fail-closed, like the gateway). Set true
+   * only where availability outranks billing.
+   */
+  failOpen?: boolean
+  /** Request timeout in ms. Default 5000 (the gateway's value). */
+  timeoutMs?: number
+}
+
+/** Who to authorize / charge. user is the IAM "org/sub" identity. */
+export type MeteringIdentity = {
+  user: string
+  org?: string
+  currency?: string
+}
+
+/** One usage event to record. Mirrors commerce's usageRequest one-for-one. */
+export type UsageEvent = {
+  user: string
+  org?: string
+  /** Cost to debit, in cents. */
+  amount: number
+  currency?: string
+  model?: string
+  provider?: string
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  requestId?: string
+  premium?: boolean
+  stream?: boolean
+  status?: string
+  clientIp?: string
+}
+
+/** Result of a usage write. */
+export type RecordResult = {
+  transactionId: string
+  user: string
+  amount: number
+  currency: string
+  type: string
+}
+
+/** Outcome of an authorize() gate. */
+export type AuthDecision = {
+  allowed: boolean
+  /** 'insufficient_balance' -> 402 ; 'balance_unavailable' -> 503 (fail-closed). */
+  reason?: 'insufficient_balance' | 'balance_unavailable'
+  /** Spendable balance in cents that the decision was based on (when known). */
+  available?: number
+}
+
+/**
+ * Metering is the server-side hook a product uses to charge for usage. It is
+ * safe to share a single instance across requests.
+ */
+export class Metering {
+  private readonly commerce: Commerce | null
+  private readonly org: string
+  private readonly tierAware: boolean
+  private readonly failOpen: boolean
+
+  constructor(config: MeteringConfig = {}) {
+    const baseUrl = (config.baseUrl ?? '').replace(/\/+$/, '')
+    this.commerce = baseUrl
+      ? new Commerce({ baseUrl, token: config.token, timeoutMs: config.timeoutMs ?? 5000 })
+      : null
+    this.org = (config.org ?? '').trim()
+    this.tierAware = config.tierAware ?? false
+    this.failOpen = config.failOpen ?? false
+  }
+
+  /**
+   * Build a Metering instance from the canonical environment variables. This
+   * is the one-liner products use at startup. Honors METERING_DISABLED for
+   * local dev.
+   */
+  static fromEnv(env: Record<string, string | undefined> = readEnv()): Metering {
+    if (truthy(env.METERING_DISABLED)) return new Metering({})
+    return new Metering({
+      baseUrl: (env.COMMERCE_URL ?? '').trim() || DEFAULT_COMMERCE_URL,
+      token: env.COMMERCE_SERVICE_TOKEN,
+      org: (env.COMMERCE_SERVICE_ORG ?? '').trim() || 'hanzo',
+      tierAware: truthy(env.METERING_TIER_AWARE),
+      failOpen: truthy(env.METERING_FAIL_OPEN),
+    })
+  }
+
+  /** Whether a commerce base URL is configured. */
+  get enabled(): boolean {
+    return this.commerce !== null
+  }
+
+  /**
+   * Pre-request balance gate. Never throws — returns a decision so callers map
+   * it to a status code. When not configured it always allows.
+   *
+   * Outcomes (matching the gateway):
+   *   { allowed: true }                                    -> allow.
+   *   { allowed: false, reason: 'insufficient_balance' }   -> 402 (out of funds).
+   *   { allowed: false, reason: 'balance_unavailable' }    -> 503 (fail-closed).
+   */
+  async authorize(id: MeteringIdentity): Promise<AuthDecision> {
+    if (!this.commerce) return { allowed: true }
+
+    const user = (id.user ?? '').trim()
+    if (!user) {
+      return this.failOpen ? { allowed: true } : { allowed: false, reason: 'balance_unavailable' }
+    }
+
+    const headers = orgHeader(id.org ?? this.org)
+    try {
+      const available = this.tierAware
+        ? (await this.commerce.getTier(user, { headers })).balance.effectiveAvailable
+        : (await this.commerce.getBalance(user, id.currency ?? 'usd', undefined, headers)).available
+
+      if (available > 0) return { allowed: true, available }
+      return { allowed: false, reason: 'insufficient_balance', available }
+    } catch {
+      // Balance unknown (commerce unreachable / non-2xx).
+      if (this.failOpen) return { allowed: true }
+      return { allowed: false, reason: 'balance_unavailable' }
+    }
+  }
+
+  /**
+   * Record a usage event, debiting the user's balance. No-op when not
+   * configured or amount <= 0 (commerce treats zero-cost usage as skipped).
+   * Decoupled from gating: the work already happened, so balance is not
+   * re-checked here. Returns null on no-op.
+   */
+  async record(usage: UsageEvent): Promise<RecordResult | null> {
+    if (!this.commerce || usage.amount <= 0) return null
+    if (!usage.user?.trim()) throw new Error('metering: record requires a user')
+
+    const headers = orgHeader(usage.org ?? this.org)
+    // Commerce's usageRequest field names map one-for-one; org travels via the
+    // header, never the body.
+    const body = {
+      user: usage.user,
+      currency: usage.currency ?? 'usd',
+      amount: usage.amount,
+      model: usage.model,
+      provider: usage.provider,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      totalTokens: usage.totalTokens,
+      requestId: usage.requestId,
+      premium: usage.premium,
+      stream: usage.stream,
+      status: usage.status,
+      clientIp: usage.clientIp,
+    }
+    const tx = await this.commerce.addUsageRecord(body as never, undefined, headers)
+    // Commerce returns { transactionId, user, amount, currency, type }.
+    return tx as unknown as RecordResult
+  }
+
+  /**
+   * Convenience for products that prefer to throw on denial. Throws a
+   * {@link CommerceApiError} with status 402 (insufficient) or 503 (unknown).
+   */
+  async authorizeOrThrow(id: MeteringIdentity): Promise<void> {
+    const decision = await this.authorize(id)
+    if (decision.allowed) return
+    if (decision.reason === 'insufficient_balance') {
+      throw new CommerceApiError(402, 'Insufficient balance. Please add credits at console.hanzo.ai')
+    }
+    throw new CommerceApiError(503, 'Billing temporarily unavailable')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Identity from gateway-minted headers (the trust boundary)
+// ---------------------------------------------------------------------------
+
+/** Gateway-minted identity headers. */
+export const HEADER_USER_ID = 'x-user-id'
+export const HEADER_ORG_ID = 'x-org-id'
+
+/**
+ * Build a {@link MeteringIdentity} from gateway-minted identity headers. The
+ * user is "{org}/{sub}" (commerce's iam-user form) when both are present.
+ * Accepts a header bag with string | string[] | undefined values (Node http,
+ * Next.js, fetch Headers via Object.fromEntries).
+ */
+export function identityFromHeaders(
+  headers: Record<string, string | string[] | undefined> | Headers,
+): MeteringIdentity {
+  const get = (k: string): string => {
+    if (typeof (headers as Headers).get === 'function') {
+      return ((headers as Headers).get(k) ?? '').trim()
+    }
+    const v = (headers as Record<string, string | string[] | undefined>)[k]
+    return (Array.isArray(v) ? v[0] : v ?? '').trim()
+  }
+  const org = get(HEADER_ORG_ID)
+  const sub = get(HEADER_USER_ID)
+  const user = org && sub ? `${org}/${sub}` : sub
+  return { user, org }
+}
+
+// ---------------------------------------------------------------------------
+// internals
+// ---------------------------------------------------------------------------
+
+function orgHeader(org: string): Record<string, string> | undefined {
+  const o = (org ?? '').trim()
+  return o ? { 'X-IAM-Org-Id': o } : undefined
+}
+
+function truthy(v: string | undefined): boolean {
+  const s = (v ?? '').trim().toLowerCase()
+  return s === 'true' || s === '1' || s === 'yes'
+}
+
+function readEnv(): Record<string, string | undefined> {
+  // Node/edge: process.env when present, else empty (browser).
+  const g = globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }
+  return g.process?.env ?? {}
+}

--- a/pkg/commerce/package.json
+++ b/pkg/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzo/commerce",
-  "version": "7.6.1",
+  "version": "7.6.2",
   "description": "e-commerce framework.",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
@@ -30,6 +30,7 @@
     "./types": "./types/index.ts",
     "./client": "./client.ts",
     "./billing": "./billing.ts",
+    "./metering": "./metering.ts",
     "./debug": "./service/debug.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## What

The TypeScript counterpart of `github.com/hanzoai/go-sdk/metering` — the one way every Hanzo TS/JS product meters usage to **commerce** (the billing source of truth) so everything can be paid for, not just the LLM/cloud path. New module `@hanzo/commerce/metering`. (universe task #28)

Shares an **identical wire contract** with the Go client.

## API

- `Metering` class — composes the existing `Commerce` client (no HTTP duplication):
  - `authorize(id)` — pre-request balance gate. Never throws; returns `{ allowed, reason }` (`insufficient_balance`→402, `balance_unavailable`→503). **Fail-closed** by default.
  - `record(usage)` — post-request usage write (debits balance). No-op on amount ≤ 0 / not-configured.
  - `tierAware` gates on `effectiveAvailable` (prepaid **+ included plan allotment**).
  - `authorizeOrThrow()` for throw-style callers.
- S2S auth: `Authorization: Bearer COMMERCE_SERVICE_TOKEN` (KMS-sourced) + `X-IAM-Org-Id`.
- `Metering.fromEnv()` — canonical env wiring (`COMMERCE_URL`, `COMMERCE_SERVICE_TOKEN`, `COMMERCE_SERVICE_ORG`, `METERING_TIER_AWARE`, `METERING_FAIL_OPEN`, `METERING_DISABLED`).
- `identityFromHeaders()` — reads gateway-minted `X-User-Id`/`X-Org-Id`.

## Client additions (DRY enablers)

- `Commerce.getTier()` — tier-aware balance (`/v1/billing/tier`).
- Optional custom `headers` on `request()`, `getBalance()`, `addUsageRecord()` — needed for the S2S `X-IAM-Org-Id` org header. Backward-compatible (trailing optional params).

## Tests

14 contract tests (mock `fetch`) mirroring the Go suite: contract shape (paths/headers/body), fail-closed/fail-open, tier-aware, per-call org override, zero-amount no-op, env wiring, identity headers. Isolated `tsc --strict` clean.

## Packaging

- `exports`: adds `./metering`; `index.ts` re-exports the public surface.
- Version `7.6.1` → `7.6.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)