### PR TITLE
feat(billing): shared CreditModal (trial + prepaid buckets, injected top-up)

### DIFF
--- a/pkgs/ui/src/billing/components/credit-modal.test.tsx
+++ b/pkgs/ui/src/billing/components/credit-modal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import * as React from 'react'
+
+import { CreditModal } from './credit-modal'
+
+// Radix Dialog relies on pointer-capture + scrollIntoView, which happy-dom lacks.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+    Element.prototype.setPointerCapture = () => {}
+    Element.prototype.releasePointerCapture = () => {}
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+})
+
+describe('CreditModal', () => {
+  it('renders nothing when closed', () => {
+    render(<CreditModal open={false} onClose={() => {}} />)
+    expect(screen.queryByText('Credits & balance')).toBeNull()
+  })
+
+  it('shows the trial + prepaid buckets distinctly with a clear total', () => {
+    render(
+      <CreditModal open onClose={() => {}} trialBalanceCents={500} prepaidBalanceCents={1234} />,
+    )
+    // Two distinct buckets.
+    expect(screen.getByText('$5.00')).toBeInTheDocument()
+    expect(screen.getByText('$12.34')).toBeInTheDocument()
+    // Combined breakdown + explicit total.
+    expect(screen.getByText('$5.00 trial + $12.34 credits')).toBeInTheDocument()
+    expect(screen.getByText('Total $17.34')).toBeInTheDocument()
+  })
+
+  it('shows the welcome celebration for new users', () => {
+    render(
+      <CreditModal
+        open
+        onClose={() => {}}
+        isNewUser
+        trialGrantedCents={500}
+        trialBalanceCents={500}
+      />,
+    )
+    expect(screen.getByText("You've got $5.00 in free credits")).toBeInTheDocument()
+  })
+
+  it('calls onTopUp with the preset amount in cents', () => {
+    const onTopUp = vi.fn()
+    render(<CreditModal open onClose={() => {}} onTopUp={onTopUp} topUpOptions={[1000, 2500]} />)
+    fireEvent.click(screen.getByText('$25.00'))
+    expect(onTopUp).toHaveBeenCalledWith(2500)
+  })
+
+  it('converts a custom dollar amount to cents before calling onTopUp', () => {
+    const onTopUp = vi.fn()
+    render(<CreditModal open onClose={() => {}} onTopUp={onTopUp} topUpOptions={[]} />)
+    fireEvent.change(screen.getByPlaceholderText('Custom amount'), { target: { value: '7.50' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(onTopUp).toHaveBeenCalledWith(750)
+  })
+
+  it('does not call onTopUp while busy', () => {
+    const onTopUp = vi.fn()
+    render(<CreditModal open onClose={() => {}} onTopUp={onTopUp} topUpOptions={[1000]} busy />)
+    fireEvent.click(screen.getByText('$10.00'))
+    expect(onTopUp).not.toHaveBeenCalled()
+  })
+
+  it('hides the top-up affordance when no onTopUp is supplied', () => {
+    render(<CreditModal open onClose={() => {}} prepaidBalanceCents={1000} />)
+    expect(screen.queryByText('Add credits')).toBeNull()
+  })
+
+  it('surfaces an error message', () => {
+    render(<CreditModal open onClose={() => {}} error="Card declined" />)
+    expect(screen.getByRole('alert')).toHaveTextContent('Card declined')
+  })
+})

--- a/pkgs/ui/src/billing/components/credit-modal.tsx
+++ b/pkgs/ui/src/billing/components/credit-modal.tsx
@@ -1,0 +1,198 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../../../primitives/dialog'
+
+/**
+ * Default preset top-up amounts, in cents ($10 / $25 / $50 / $100).
+ * Callers may override via `topUpOptions`.
+ */
+const DEFAULT_TOP_UP_OPTIONS = [1000, 2500, 5000, 10000]
+
+export interface CreditModalProps {
+  /** Controls visibility. */
+  open: boolean
+  /** Fired on escape, overlay click, or the close affordance. */
+  onClose: () => void
+  /** Non-cash promotional trial credit remaining, in cents. */
+  trialBalanceCents?: number
+  /** Real (paid) prepaid credit remaining, in cents. */
+  prepaidBalanceCents?: number
+  /** Trial credit originally granted, in cents — drives the welcome copy. */
+  trialGrantedCents?: number
+  /** ISO 4217 currency code. */
+  currency?: string
+  /** Preset top-up amounts, in cents. */
+  topUpOptions?: number[]
+  /**
+   * Injected top-up handler. The Square/HUSD payment flow lives in the caller;
+   * this modal only presents amounts + buckets, then hands back the chosen cents.
+   * Omit to render a read-only balance view.
+   */
+  onTopUp?: (amountCents: number) => void | Promise<void>
+  /** First-run celebration state (e.g. trial credit just landed). */
+  isNewUser?: boolean
+  /** Disables actions while a payment/settlement is in flight. */
+  busy?: boolean
+  /** Error to surface (e.g. a failed charge). */
+  error?: string | null
+  /**
+   * Optional caller-injected payment surface (e.g. <SquareCardForm/>),
+   * rendered below the amount picker.
+   */
+  children?: React.ReactNode
+  /** Overrides the default (non-welcome) heading. */
+  title?: string
+}
+
+function formatCents(cents: number, currency: string) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+  }).format((cents || 0) / 100)
+}
+
+export function CreditModal({
+  open,
+  onClose,
+  trialBalanceCents = 0,
+  prepaidBalanceCents = 0,
+  trialGrantedCents,
+  currency = 'usd',
+  topUpOptions = DEFAULT_TOP_UP_OPTIONS,
+  onTopUp,
+  isNewUser = false,
+  busy = false,
+  error,
+  children,
+  title = 'Credits & balance',
+}: CreditModalProps) {
+  const [custom, setCustom] = React.useState('')
+
+  const totalCents = trialBalanceCents + prepaidBalanceCents
+  const welcomeCents = trialGrantedCents ?? trialBalanceCents
+  const showWelcome = isNewUser && welcomeCents > 0
+
+  const customCents = React.useMemo(() => {
+    const dollars = Number.parseFloat(custom)
+    if (!Number.isFinite(dollars) || dollars <= 0) return 0
+    return Math.round(dollars * 100)
+  }, [custom])
+
+  const topUp = React.useCallback(
+    (cents: number) => {
+      if (busy || cents <= 0 || !onTopUp) return
+      void onTopUp(cents)
+    },
+    [busy, onTopUp],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose() }}>
+      <DialogContent className="max-w-md border-border bg-bg-card text-text">
+        <DialogHeader>
+          <DialogTitle className="text-text">
+            {showWelcome
+              ? `You've got ${formatCents(welcomeCents, currency)} in free credits`
+              : title}
+          </DialogTitle>
+          <DialogDescription className="text-text-muted">
+            {showWelcome
+              ? 'Start building — trial credit is applied automatically before any charge.'
+              : 'Trial credit is applied before your prepaid balance.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Two distinct buckets: promo trial credit vs. real prepaid money */}
+        <div className="overflow-hidden rounded-xl border border-border bg-bg">
+          <div className="grid grid-cols-2 divide-x divide-border">
+            <div className="p-4">
+              <div className="flex items-center gap-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">Trial</p>
+                <span className="rounded-full bg-warning/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-warning">
+                  Promo
+                </span>
+              </div>
+              <p className="mt-1 text-2xl font-bold text-text">{formatCents(trialBalanceCents, currency)}</p>
+              <p className="mt-0.5 text-xs text-text-dim">Non-cash credit</p>
+            </div>
+            <div className="p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-text-muted">Prepaid</p>
+              <p className="mt-1 text-2xl font-bold text-text">{formatCents(prepaidBalanceCents, currency)}</p>
+              <p className="mt-0.5 text-xs text-text-dim">Paid credit</p>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border px-4 py-3">
+            <span className="text-sm text-text-muted">
+              {formatCents(trialBalanceCents, currency)} trial + {formatCents(prepaidBalanceCents, currency)} credits
+            </span>
+            <span className="text-sm font-semibold text-text">Total {formatCents(totalCents, currency)}</span>
+          </div>
+        </div>
+
+        {/* Top-up affordance. The payment execution is injected via onTopUp. */}
+        {onTopUp && (
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-text">Add credits</p>
+            {topUpOptions.length > 0 && (
+              <div className="grid grid-cols-4 gap-2">
+                {topUpOptions.map((cents) => (
+                  <button
+                    key={cents}
+                    type="button"
+                    disabled={busy}
+                    onClick={() => topUp(cents)}
+                    className="rounded-lg border border-border bg-bg px-3 py-2 text-sm font-semibold text-text transition hover:bg-bg-elevated disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {formatCents(cents, currency)}
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <div className="relative flex-1">
+                <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-text-dim">$</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={custom}
+                  onChange={(e) => setCustom(e.target.value)}
+                  placeholder="Custom amount"
+                  disabled={busy}
+                  className="w-full rounded-lg border border-border bg-bg py-2 pl-7 pr-3 text-sm text-text placeholder:text-text-dim focus:border-brand focus:outline-none disabled:opacity-60"
+                />
+              </div>
+              <button
+                type="button"
+                disabled={busy || customCents <= 0}
+                onClick={() => topUp(customCents)}
+                className="rounded-lg bg-brand px-5 py-2 text-sm font-semibold text-brand-foreground transition hover:bg-brand-hover active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {busy ? 'Processing…' : 'Add'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Injected payment surface (e.g. <SquareCardForm/> or an HUSD flow). */}
+        {children}
+
+        {error && (
+          <p role="alert" className="text-sm text-danger">
+            {error}
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/pkgs/ui/src/billing/components/index.ts
+++ b/pkgs/ui/src/billing/components/index.ts
@@ -25,6 +25,9 @@ export type { UsagePanelProps } from './usage-panel'
 export { CreditsPanel } from './credits-panel'
 export type { CreditsPanelProps } from './credits-panel'
 
+export { CreditModal } from './credit-modal'
+export type { CreditModalProps } from './credit-modal'
+
 export { TransactionsPanel } from './transactions-panel'
 export type { TransactionsPanelProps } from './transactions-panel'
 


### PR DESCRIPTION
## What

Adds a **shared, reusable `CreditModal`** to `@hanzo/ui/billing` so every Hanzo
app renders the *same* credit / top-up modal. It is **presentational and
self-contained**: all data + handlers are injected via props (cents-based,
following the commerce balance shape). No network calls, no app coupling.

### Behaviour
- **Two distinct buckets** — non-cash promotional *trial* credit vs. real
  *prepaid* money — with a combined breakdown (`$5.00 trial + $X.XX credits`)
  and an explicit **Total**.
- **Welcome celebration** state for new users (`isNewUser` + trial credit just
  landed): "You've got $5.00 in free credits — start building."
- **Top-up affordance**: preset amount buttons + a custom amount, which call
  the injected `onTopUp(amountCents)`. The actual Square/HUSD payment flow is
  **not** implemented here — it is injected. Callers either handle `onTopUp`
  (open their own payment sheet) and/or render a payment surface via `children`
  (e.g. the existing `<SquareCardForm onToken=… />`). This reuses the package's
  existing handler-prop pattern (`onAddFunds` / `SquareCardForm`) rather than
  duplicating a payment primitive.
- **Accessible + theme-aware**: reuses the package radix `Dialog` primitive
  (`@hanzo/ui/primitives/dialog`) for focus trap, escape-to-close, overlay, and
  aria — no hand-rolled modal. Styled with the billing semantic tokens
  (`bg-bg-card`, `text-text`, `border-border`, `bg-brand`, `text-warning`, …),
  matching every other billing component; no new styling approach introduced.

### Props
```ts
interface CreditModalProps {
  open: boolean
  onClose: () => void
  trialBalanceCents?: number      // non-cash promo credit remaining
  prepaidBalanceCents?: number    // real paid credit remaining
  trialGrantedCents?: number      // drives the welcome copy
  currency?: string               // default 'usd'
  topUpOptions?: number[]         // preset amounts in cents; default [1000,2500,5000,10000]
  onTopUp?: (amountCents: number) => void | Promise<void>
  isNewUser?: boolean
  busy?: boolean
  error?: string | null
  children?: React.ReactNode      // injected payment surface (e.g. SquareCardForm)
  title?: string
}
```

## Files
- `pkgs/ui/src/billing/components/credit-modal.tsx` — the component (new)
- `pkgs/ui/src/billing/components/credit-modal.test.tsx` — 8 vitest cases (new)
- `pkgs/ui/src/billing/components/index.ts` — export from the billing barrel

Importable as a first-class billing component:
```ts
import { CreditModal, type CreditModalProps } from '@hanzo/ui/billing'
```

## Verification
- `tsc --project tsconfig.build.json --noEmit` → **0 errors** (whole package)
- `tsup --config tsup.config.minimal.ts` → billing entry builds; `CreditModal`
  present in `dist/billing/index.mjs`
- `vitest run credit-modal.test.tsx` → **8/8 passed** (closed/open, two buckets +
  total, welcome state, preset → cents, custom $ → cents, busy guard, top-up
  hidden without `onTopUp`, error surfaced)

## Adoption — how each app mounts it (not rewired in this PR)

The modal is a pure presentation surface; each app supplies its own data +
handlers from its own commerce/billing source.

- **console2** — owns full account billing. Wire real balances + a real charge:
  ```tsx
  <CreditModal
    open={open} onClose={close}
    trialBalanceCents={balance.trialCents}
    prepaidBalanceCents={balance.prepaidCents}
    currency={balance.currency}
    busy={charging} error={chargeError}
    onTopUp={(cents) => billing.deposit(cents)}   // POST commerce /v1/billing/deposit
  />
  ```
- **hanzo.app** — first-run / builder surface. Show the welcome celebration when
  the $5 trial grant just landed, and defer payment to the shared handler:
  ```tsx
  <CreditModal
    open onClose={dismiss}
    isNewUser trialGrantedCents={500} trialBalanceCents={500}
    prepaidBalanceCents={0}
    onTopUp={openCheckout}
  />
  ```
- **billing.hanzo.ai** — dedicated billing app; render the Square card form as an
  injected child so the amount picker + buckets stay shared while payment stays
  app-owned:
  ```tsx
  <CreditModal
    open onClose={close}
    trialBalanceCents={t} prepaidBalanceCents={p}
    onTopUp={setPendingCents}
  >
    <SquareCardForm onToken={(sourceId) => charge(sourceId, pendingCents)} />
  </CreditModal>
  ```

Each app injects its own data/handlers; the modal, buckets, welcome state, and
amount picker are identical across all three.
