### PR TITLE
feat(network,wallet): shared NetworkSwitcher + WalletMenu — the ONE hanzo.network standard

### DIFF
--- a/pkgs/ui/components/index.ts
+++ b/pkgs/ui/components/index.ts
@@ -1,6 +1,6 @@
 // Component exports
 // This file provides a central import point for all UI components
-// Usage: import { Button, Card, cn } from '@hanzo/ui/components'
+// Usage: import { Button, Card, cn } from '@hanzo/ui-shadcn/components'
 
 // Export commonly used utilities
 export { cn, formatDate, absoluteUrl } from '../src/utils'

--- a/pkgs/ui/package.json
+++ b/pkgs/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzo/ui-shadcn",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Multi-framework UI library with React, Vue, Svelte, and React Native support. Based on shadcn/ui with comprehensive framework coverage. (Formerly @hanzo/ui \u22645.x; @hanzo/ui@8+ is the @hanzo/gui-based unified lib.)",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/pkgs/ui/package.json
+++ b/pkgs/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hanzo/ui-shadcn",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "Multi-framework UI library with React, Vue, Svelte, and React Native support. Based on shadcn/ui with comprehensive framework coverage. (Formerly @hanzo/ui \u22645.x; @hanzo/ui@8+ is the @hanzo/gui-based unified lib.)",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/pkgs/ui/package.json
+++ b/pkgs/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hanzo/ui-shadcn",
-  "version": "5.7.1",
-  "description": "Multi-framework UI library with React, Vue, Svelte, and React Native support. Based on shadcn/ui with comprehensive framework coverage. (Formerly @hanzo/ui ≤5.x; @hanzo/ui@8+ is the @hanzo/gui-based unified lib.)",
+  "version": "5.7.2",
+  "description": "Multi-framework UI library with React, Vue, Svelte, and React Native support. Based on shadcn/ui with comprehensive framework coverage. (Formerly @hanzo/ui \u22645.x; @hanzo/ui@8+ is the @hanzo/gui-based unified lib.)",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
@@ -526,6 +526,16 @@
       "types": "./dist/src/auth/*.d.ts",
       "import": "./dist/auth/*.mjs",
       "require": "./dist/auth/*.js"
+    },
+    "./network": {
+      "types": "./dist/src/network/index.d.ts",
+      "import": "./dist/network/index.mjs",
+      "require": "./dist/network/index.js"
+    },
+    "./wallet": {
+      "types": "./dist/src/wallet/index.d.ts",
+      "import": "./dist/wallet/index.mjs",
+      "require": "./dist/wallet/index.js"
     },
     "./navigation": {
       "types": "./dist/src/navigation/index.d.ts",

--- a/pkgs/ui/primitives/charts/index.ts
+++ b/pkgs/ui/primitives/charts/index.ts
@@ -8,5 +8,5 @@ export * from './radial'
 export * from './tooltip'
 
 // Note: Chart primitives (ChartContainer, ChartConfig, etc.) should be imported directly:
-// import { ChartContainer } from '@hanzo/ui/primitives/chart'
+// import { ChartContainer } from '@hanzo/ui-shadcn/primitives/chart'
 // Not from charts/index to avoid circular dependencies

--- a/pkgs/ui/primitives/index-core.ts
+++ b/pkgs/ui/primitives/index-core.ts
@@ -26,8 +26,8 @@ export { cn } from '../src/utils'
  * 
  * For more components, import them individually:
  * 
- * import { Dialog } from '@hanzo/ui/dialog'
- * import { Select } from '@hanzo/ui/select'
- * import { Badge } from '@hanzo/ui/badge'
+ * import { Dialog } from '@hanzo/ui-shadcn/dialog'
+ * import { Select } from '@hanzo/ui-shadcn/select'
+ * import { Badge } from '@hanzo/ui-shadcn/badge'
  * etc.
  */

--- a/pkgs/ui/primitives/index-selective.ts
+++ b/pkgs/ui/primitives/index-selective.ts
@@ -231,9 +231,9 @@ export type { InputProps } from './input'
  * These are NOT exported here to avoid loading their dependencies
  * Users should import them specifically when needed:
  * 
- * import { Calendar } from '@hanzo/ui/calendar'
- * import { Command } from '@hanzo/ui/command'
- * import { Carousel } from '@hanzo/ui/carousel'
- * import { Form } from '@hanzo/ui/form'
+ * import { Calendar } from '@hanzo/ui-shadcn/calendar'
+ * import { Command } from '@hanzo/ui-shadcn/command'
+ * import { Carousel } from '@hanzo/ui-shadcn/carousel'
+ * import { Form } from '@hanzo/ui-shadcn/form'
  * etc.
  */

--- a/pkgs/ui/primitives/index-standard.ts
+++ b/pkgs/ui/primitives/index-standard.ts
@@ -176,7 +176,7 @@ export {
   FieldSeparator,
 } from './field'
 
-// Form components available via '@hanzo/ui/form' - NOT bundled here due to
+// Form components available via '@hanzo/ui-shadcn/form' - NOT bundled here due to
 // react-hook-form ESM/CJS interop issues with Next.js 15 when bundled
 
 export {
@@ -335,7 +335,7 @@ export { Spinner } from './spinner'
 export { default as StepIndicator } from './step-indicator'
 export { default as Switch } from './switch'
 export { Textarea } from './textarea'
-// TextField available via @hanzo/ui/form - requires react-hook-form
+// TextField available via @hanzo/ui-shadcn/form - requires react-hook-form
 export { Toaster, toast } from './sonner'
 export { Toggle, toggleVariants } from './toggle'
 export { ToggleGroup, ToggleGroupItem } from './toggle-group'
@@ -378,11 +378,11 @@ export { YouTubePipPlayer, youtubePipPlayerVariants } from './youtube-pip-player
 export * from '../assets'
 
 // NOTE: Docs components are NOT re-exported here to avoid path alias resolution issues
-// during build. Import directly from @hanzo/ui/docs/* if needed:
-//   - DocsLayout: @hanzo/ui/docs/layouts/docs
-//   - HomeLayout: @hanzo/ui/docs/layouts/home
-//   - NotebookLayout: @hanzo/ui/docs/layouts/notebook
-//   - DocsPage, DocsBody, DocsTitle, DocsDescription: @hanzo/ui/docs/page
-//   - defaultMdxComponents: @hanzo/ui/docs/mdx
-//   - RootProvider: @hanzo/ui/docs/provider/next
-//   - loader: @hanzo/ui/docs/source
+// during build. Import directly from @hanzo/ui-shadcn/docs/* if needed:
+//   - DocsLayout: @hanzo/ui-shadcn/docs/layouts/docs
+//   - HomeLayout: @hanzo/ui-shadcn/docs/layouts/home
+//   - NotebookLayout: @hanzo/ui-shadcn/docs/layouts/notebook
+//   - DocsPage, DocsBody, DocsTitle, DocsDescription: @hanzo/ui-shadcn/docs/page
+//   - defaultMdxComponents: @hanzo/ui-shadcn/docs/mdx
+//   - RootProvider: @hanzo/ui-shadcn/docs/provider/next
+//   - loader: @hanzo/ui-shadcn/docs/source

--- a/pkgs/ui/primitives/next/media-stack.tsx
+++ b/pkgs/ui/primitives/next/media-stack.tsx
@@ -21,7 +21,7 @@ const MediaStack: React.FC<{
   const transform = mediaTransform ?? {}
 
   // Order of precedence: MP4 > Image
-  // For 3D/Spline support, use @hanzo/ui/spline MediaStack instead
+  // For 3D/Spline support, use @hanzo/ui-shadcn/spline MediaStack instead
   if (video) {
     const dim = constrain(video.dim.md, cnst)
     return (

--- a/pkgs/ui/src/3d/button.tsx
+++ b/pkgs/ui/src/3d/button.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 const button3DVariants = cva(
   [

--- a/pkgs/ui/src/3d/card.tsx
+++ b/pkgs/ui/src/3d/card.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface Point {
   x: number

--- a/pkgs/ui/src/3d/carousel.tsx
+++ b/pkgs/ui/src/3d/carousel.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface Carousel3DItem {
   id: string

--- a/pkgs/ui/src/3d/grid.tsx
+++ b/pkgs/ui/src/3d/grid.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface Grid3DItem {
   id: string

--- a/pkgs/ui/src/3d/marquee.tsx
+++ b/pkgs/ui/src/3d/marquee.tsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { motion } from "framer-motion"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 const marquee3DVariants = cva(
   [

--- a/pkgs/ui/src/3d/pin.tsx
+++ b/pkgs/ui/src/3d/pin.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { motion } from "framer-motion"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface Pin3DProps extends React.HTMLAttributes<HTMLDivElement> {
   title?: string

--- a/pkgs/ui/src/animation/apple-cards-carousel.tsx
+++ b/pkgs/ui/src/animation/apple-cards-carousel.tsx
@@ -10,7 +10,7 @@ import {
 } from "framer-motion"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 import { Button } from "@hanzo/ui"
 import { Card } from "@hanzo/ui"
 

--- a/pkgs/ui/src/animation/apple-hello-effect.tsx
+++ b/pkgs/ui/src/animation/apple-hello-effect.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { motion } from "framer-motion"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface AppleHelloEffectProps extends React.HTMLAttributes<HTMLDivElement> {
   text?: string

--- a/pkgs/ui/src/animation/beam.tsx
+++ b/pkgs/ui/src/animation/beam.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { motion } from "motion/react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface AnimatedBeamProps extends React.SVGAttributes<SVGSVGElement> {
   duration?: number

--- a/pkgs/ui/src/animation/cursor.tsx
+++ b/pkgs/ui/src/animation/cursor.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 export interface AnimatedCursorProps {
   /**

--- a/pkgs/ui/src/animation/testimonials.tsx
+++ b/pkgs/ui/src/animation/testimonials.tsx
@@ -3,12 +3,12 @@
 import * as React from "react"
 import { AnimatePresence, motion } from "motion/react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
-} from "@hanzo/ui/primitives/avatar"
+} from "@hanzo/ui-shadcn/primitives/avatar"
 import { Card, CardContent } from "@hanzo/ui"
 
 interface Testimonial {

--- a/pkgs/ui/src/animation/tooltip.tsx
+++ b/pkgs/ui/src/animation/tooltip.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { AnimatePresence, motion } from "framer-motion"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 interface AnimatedTooltipProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "content"> {

--- a/pkgs/ui/src/billing/index.ts
+++ b/pkgs/ui/src/billing/index.ts
@@ -1,5 +1,5 @@
 /**
- * @hanzo/ui/billing
+ * @hanzo/ui-shadcn/billing
  * Billing, subscription, payment, and invoice management components
  */
 

--- a/pkgs/ui/src/calendar-ext/index.ts
+++ b/pkgs/ui/src/calendar-ext/index.ts
@@ -1,4 +1,4 @@
-// @hanzo/ui/calendar-ext - Extended calendar components
+// @hanzo/ui-shadcn/calendar-ext - Extended calendar components
 // Requires: npm install react-day-picker date-fns chrono-node
 
 // Re-export base calendar

--- a/pkgs/ui/src/charts/index.ts
+++ b/pkgs/ui/src/charts/index.ts
@@ -1,4 +1,4 @@
-// @hanzo/ui/charts - Chart components powered by Recharts
+// @hanzo/ui-shadcn/charts - Chart components powered by Recharts
 // Requires: npm install recharts
 
 // Core chart primitives

--- a/pkgs/ui/src/code/block.tsx
+++ b/pkgs/ui/src/code/block.tsx
@@ -5,10 +5,10 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { Check, Copy, FileText } from "lucide-react"
 import { codeToHtml } from "shiki"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Badge } from "@hanzo/ui/badge"
-import { Button } from "@hanzo/ui/button"
-import { Skeleton } from "@hanzo/ui/skeleton"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Badge } from "@hanzo/ui-shadcn/badge"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { Skeleton } from "@hanzo/ui-shadcn/skeleton"
 
 const codeBlockVariants = cva(
   "relative overflow-hidden rounded-lg border bg-muted/50",

--- a/pkgs/ui/src/code/compare.tsx
+++ b/pkgs/ui/src/code/compare.tsx
@@ -14,25 +14,25 @@ import {
   SplitSquareHorizontal,
 } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Badge } from "@hanzo/ui/badge"
-import { Button } from "@hanzo/ui/button"
-import { CodeDiff } from "@hanzo/ui/code/diff"
-import { CodeSnippet } from "@hanzo/ui/code/snippet"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Badge } from "@hanzo/ui-shadcn/badge"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { CodeDiff } from "@hanzo/ui-shadcn/code/diff"
+import { CodeSnippet } from "@hanzo/ui-shadcn/code/snippet"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@hanzo/ui/dropdown-menu"
-import { ScrollArea } from "@hanzo/ui/scroll-area"
-import { Separator } from "@hanzo/ui/separator"
+} from "@hanzo/ui-shadcn/dropdown-menu"
+import { ScrollArea } from "@hanzo/ui-shadcn/scroll-area"
+import { Separator } from "@hanzo/ui-shadcn/separator"
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
-} from "@hanzo/ui/tabs"
+} from "@hanzo/ui-shadcn/tabs"
 
 const codeCompareVariants = cva(
   "relative flex flex-col overflow-hidden rounded-lg border bg-background",

--- a/pkgs/ui/src/code/diff.tsx
+++ b/pkgs/ui/src/code/diff.tsx
@@ -13,15 +13,15 @@ import {
 } from "lucide-react"
 import { codeToHtml } from "shiki"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Badge } from "@hanzo/ui/badge"
-import { Button } from "@hanzo/ui/button"
-import { Separator } from "@hanzo/ui/separator"
-import { Skeleton } from "@hanzo/ui/skeleton"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Badge } from "@hanzo/ui-shadcn/badge"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { Separator } from "@hanzo/ui-shadcn/separator"
+import { Skeleton } from "@hanzo/ui-shadcn/skeleton"
 import {
   ToggleGroup,
   ToggleGroupItem,
-} from "@hanzo/ui/toggle-group"
+} from "@hanzo/ui-shadcn/toggle-group"
 
 const codeDiffVariants = cva(
   "relative overflow-hidden rounded-lg border bg-muted/50",

--- a/pkgs/ui/src/code/editor.tsx
+++ b/pkgs/ui/src/code/editor.tsx
@@ -5,14 +5,14 @@ import Editor, { OnChange, OnMount } from "@monaco-editor/react"
 import { Check, ChevronDown, Copy } from "lucide-react"
 import { useTheme } from "next-themes"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Button } from "@hanzo/ui/button"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Button } from "@hanzo/ui-shadcn/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@hanzo/ui/dropdown-menu"
+} from "@hanzo/ui-shadcn/dropdown-menu"
 
 export interface CodeEditorProps {
   value?: string

--- a/pkgs/ui/src/code/explorer.tsx
+++ b/pkgs/ui/src/code/explorer.tsx
@@ -15,10 +15,10 @@ import {
   X,
 } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Button } from "@hanzo/ui/button"
-import { Input } from "@hanzo/ui/input"
-import { ScrollArea } from "@hanzo/ui/scroll-area"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { Input } from "@hanzo/ui-shadcn/input"
+import { ScrollArea } from "@hanzo/ui-shadcn/scroll-area"
 
 const codeExplorerVariants = cva(
   "relative flex flex-col overflow-hidden rounded-lg border bg-background",

--- a/pkgs/ui/src/code/preview.tsx
+++ b/pkgs/ui/src/code/preview.tsx
@@ -16,18 +16,18 @@ import {
   X,
 } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Badge } from "@hanzo/ui/badge"
-import { Button } from "@hanzo/ui/button"
-import { CodeSnippet } from "@hanzo/ui/code/snippet"
-import { Separator } from "@hanzo/ui/separator"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Badge } from "@hanzo/ui-shadcn/badge"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { CodeSnippet } from "@hanzo/ui-shadcn/code/snippet"
+import { Separator } from "@hanzo/ui-shadcn/separator"
 import {
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
-} from "@hanzo/ui/tabs"
-import { Toggle } from "@hanzo/ui/toggle"
+} from "@hanzo/ui-shadcn/tabs"
+import { Toggle } from "@hanzo/ui-shadcn/toggle"
 
 const codePreviewVariants = cva(
   "relative overflow-hidden rounded-lg border bg-background",

--- a/pkgs/ui/src/code/snippet.tsx
+++ b/pkgs/ui/src/code/snippet.tsx
@@ -5,10 +5,10 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { Check, Copy, FileText, Maximize2, Minimize2 } from "lucide-react"
 import { bundledLanguages, codeToHtml } from "shiki"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Badge } from "@hanzo/ui/badge"
-import { Button } from "@hanzo/ui/button"
-import { Skeleton } from "@hanzo/ui/skeleton"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Badge } from "@hanzo/ui-shadcn/badge"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { Skeleton } from "@hanzo/ui-shadcn/skeleton"
 
 const codeSnippetVariants = cva("relative group", {
   variants: {

--- a/pkgs/ui/src/code/tabs.tsx
+++ b/pkgs/ui/src/code/tabs.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 export interface CodeTabsProps extends React.HTMLAttributes<HTMLDivElement> {
   tabs?: Array<{

--- a/pkgs/ui/src/code/terminal.tsx
+++ b/pkgs/ui/src/code/terminal.tsx
@@ -17,11 +17,11 @@ import {
   X,
 } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Button } from "@hanzo/ui/button"
-import { Input } from "@hanzo/ui/input"
-import { ScrollArea } from "@hanzo/ui/scroll-area"
-import { Separator } from "@hanzo/ui/separator"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Button } from "@hanzo/ui-shadcn/button"
+import { Input } from "@hanzo/ui-shadcn/input"
+import { ScrollArea } from "@hanzo/ui-shadcn/scroll-area"
+import { Separator } from "@hanzo/ui-shadcn/separator"
 
 const codeTerminalVariants = cva(
   "relative flex flex-col overflow-hidden rounded-lg border",

--- a/pkgs/ui/src/dash/index.ts
+++ b/pkgs/ui/src/dash/index.ts
@@ -1,5 +1,5 @@
 /**
- * @hanzo/ui/dash
+ * @hanzo/ui-shadcn/dash
  *
  * Shared dash UI foundation. Dark-themed layout, navigation,
  * data table, form builder, and CRUD components.

--- a/pkgs/ui/src/dash/tokens.css
+++ b/pkgs/ui/src/dash/tokens.css
@@ -1,5 +1,5 @@
 /*
- * @hanzo/ui/dash - Shared design tokens
+ * @hanzo/ui-shadcn/dash - Shared design tokens
  *
  * Framework-agnostic CSS custom properties for dash UIs.
  * Works in React (Tailwind) and Svelte (SCSS) builds.

--- a/pkgs/ui/src/kanban/index.ts
+++ b/pkgs/ui/src/kanban/index.ts
@@ -1,4 +1,4 @@
-// @hanzo/ui/kanban - Kanban and drag-drop components
+// @hanzo/ui-shadcn/kanban - Kanban and drag-drop components
 // Requires: npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/modifiers @dnd-kit/utilities
 
 export { default as KanbanBoard } from '../project/kanban'

--- a/pkgs/ui/src/mermaid/index.ts
+++ b/pkgs/ui/src/mermaid/index.ts
@@ -1,4 +1,4 @@
-// @hanzo/ui/mermaid - Mermaid diagram rendering
+// @hanzo/ui-shadcn/mermaid - Mermaid diagram rendering
 // Requires: npm install mermaid
 
 export { MermaidDiagram as Mermaid, MermaidDiagram } from '../../primitives/mermaid'

--- a/pkgs/ui/src/models/index.ts
+++ b/pkgs/ui/src/models/index.ts
@@ -1,5 +1,5 @@
 /**
- * @hanzo/ui/models — Shared Zen model UI components
+ * @hanzo/ui-shadcn/models — Shared Zen model UI components
  *
  * Components are data-agnostic: they accept any data compatible with
  * ZenModelLike / ModelFamilyLike types, making them reusable across
@@ -8,7 +8,7 @@
  * Data source: @hanzo/zen-models (the canonical Zen model registry)
  *
  * Usage:
- *   import { ModelCard, ModelLibrary, ModelTable, ZenEnso } from '@hanzo/ui/models'
+ *   import { ModelCard, ModelLibrary, ModelTable, ZenEnso } from '@hanzo/ui-shadcn/models'
  *   import { allModels, families } from '@hanzo/zen-models'
  *   <ModelLibrary allModels={allModels} families={families} />
  */

--- a/pkgs/ui/src/network/NetworkSwitcher.tsx
+++ b/pkgs/ui/src/network/NetworkSwitcher.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+/**
+ * <NetworkSwitcher/> — the ONE network selector for every Hanzo surface
+ * (desktop, app, chat, team, console). Renders the selected environment
+ * and a menu of configured networks + a custom-endpoint form, backed by
+ * the shared selected-network store, so dropping this into a header is
+ * the whole integration.
+ *
+ * Self-contained (React + semantic Tailwind tokens only), matching the
+ * other @hanzo/ui domain modules.
+ */
+
+import * as React from 'react'
+
+import { validateCustomNetwork, type Network, type NetworkEnv } from './networks'
+import { useNetwork } from './store'
+
+const ENV_DOT: Record<NetworkEnv, string> = {
+  mainnet: 'bg-emerald-500',
+  testnet: 'bg-amber-500',
+  devnet: 'bg-sky-500',
+  local: 'bg-zinc-400',
+  custom: 'bg-violet-500',
+}
+
+export interface NetworkSwitcherProps {
+  /** Called after the selection changes (endpoint rewiring is automatic). */
+  onChange?: (network: Network) => void
+  className?: string
+}
+
+interface CustomDraft {
+  label: string
+  chainID: string
+  rpcEndpoint: string
+  apiEndpoint: string
+}
+
+const EMPTY_DRAFT: CustomDraft = { label: '', chainID: '', rpcEndpoint: '', apiEndpoint: '' }
+
+export function NetworkSwitcher({ onChange, className = '' }: NetworkSwitcherProps) {
+  const { network, networks, select, selectCustom } = useNetwork()
+  const [open, setOpen] = React.useState(false)
+  const [customOpen, setCustomOpen] = React.useState(false)
+  const [draft, setDraft] = React.useState<CustomDraft>(EMPTY_DRAFT)
+  const [error, setError] = React.useState<string | null>(null)
+  const ref = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [open])
+
+  const pick = (env: NetworkEnv) => {
+    if (env === 'custom') {
+      setCustomOpen(true)
+      return
+    }
+    const next = select(env)
+    setOpen(false)
+    setCustomOpen(false)
+    onChange?.(next)
+  }
+
+  const saveCustom = () => {
+    const candidate: Omit<Network, 'env'> = {
+      label: draft.label.trim() || 'Custom',
+      networkID: Number(draft.chainID),
+      evmChainID: Number(draft.chainID),
+      rpcEndpoint: draft.rpcEndpoint.trim(),
+      apiEndpoint: draft.apiEndpoint.trim(),
+      currency: network.currency,
+    }
+    const invalid = validateCustomNetwork({ ...candidate, env: 'custom' })
+    if (invalid) {
+      setError(invalid)
+      return
+    }
+    const next = selectCustom(candidate)
+    setError(null)
+    setDraft(EMPTY_DRAFT)
+    setOpen(false)
+    setCustomOpen(false)
+    onChange?.(next)
+  }
+
+  const field =
+    'w-full rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring'
+
+  return (
+    <div ref={ref} className={`relative ${className}`}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        <span className={`h-2 w-2 rounded-full ${ENV_DOT[network.env]}`} aria-hidden />
+        <span className="max-w-[9rem] truncate">{network.label}</span>
+        <svg
+          className={`h-3 w-3 text-muted-foreground transition-transform ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+          aria-hidden
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-1.5 w-64 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          {networks.map((n) => (
+            <button
+              key={n.env}
+              type="button"
+              role="menuitemradio"
+              aria-checked={network.env === n.env}
+              onClick={() => pick(n.env)}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground"
+            >
+              <span className={`h-2 w-2 shrink-0 rounded-full ${ENV_DOT[n.env]}`} aria-hidden />
+              <span className="flex-1">
+                <span className="block font-medium">{n.label}</span>
+                <span className="block text-[10px] text-muted-foreground">
+                  chain {n.evmChainID} &middot; {n.rpcEndpoint.replace(/^https?:\/\//, '')}
+                </span>
+              </span>
+              {network.env === n.env && (
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </button>
+          ))}
+
+          <div className="my-1 h-px bg-border" role="separator" />
+
+          {!customOpen ? (
+            <button
+              type="button"
+              role="menuitemradio"
+              aria-checked={network.env === 'custom'}
+              onClick={() => pick('custom')}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground"
+            >
+              <span className={`h-2 w-2 shrink-0 rounded-full ${ENV_DOT.custom}`} aria-hidden />
+              <span className="flex-1 font-medium">
+                {network.env === 'custom' ? network.label : 'Custom…'}
+              </span>
+              {network.env === 'custom' && (
+                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </button>
+          ) : (
+            <form
+              className="space-y-1.5 p-2"
+              onSubmit={(e) => {
+                e.preventDefault()
+                saveCustom()
+              }}
+            >
+              <input
+                className={field}
+                placeholder="Label (optional)"
+                value={draft.label}
+                onChange={(e) => setDraft({ ...draft, label: e.target.value })}
+              />
+              <input
+                className={field}
+                placeholder="Chain ID"
+                inputMode="numeric"
+                value={draft.chainID}
+                onChange={(e) => setDraft({ ...draft, chainID: e.target.value })}
+              />
+              <input
+                className={field}
+                placeholder="RPC endpoint (https://…)"
+                value={draft.rpcEndpoint}
+                onChange={(e) => setDraft({ ...draft, rpcEndpoint: e.target.value })}
+              />
+              <input
+                className={field}
+                placeholder="API endpoint (https://…)"
+                value={draft.apiEndpoint}
+                onChange={(e) => setDraft({ ...draft, apiEndpoint: e.target.value })}
+              />
+              {error && <p className="text-[10px] text-destructive">{error}</p>}
+              <div className="flex justify-end gap-1.5 pt-0.5">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setCustomOpen(false)
+                    setError(null)
+                  }}
+                  className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:opacity-90"
+                >
+                  Connect
+                </button>
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/pkgs/ui/src/network/NetworkSwitcher.tsx
+++ b/pkgs/ui/src/network/NetworkSwitcher.tsx
@@ -27,6 +27,8 @@ const ENV_DOT: Record<NetworkEnv, string> = {
 export interface NetworkSwitcherProps {
   /** Called after the selection changes (endpoint rewiring is automatic). */
   onChange?: (network: Network) => void
+  /** Where the menu opens relative to the trigger (headers: bottom; footers: top). */
+  menuSide?: 'top' | 'bottom'
   className?: string
 }
 
@@ -39,7 +41,7 @@ interface CustomDraft {
 
 const EMPTY_DRAFT: CustomDraft = { label: '', chainID: '', rpcEndpoint: '', apiEndpoint: '' }
 
-export function NetworkSwitcher({ onChange, className = '' }: NetworkSwitcherProps) {
+export function NetworkSwitcher({ onChange, menuSide = 'bottom', className = '' }: NetworkSwitcherProps) {
   const { network, networks, select, selectCustom } = useNetwork()
   const [open, setOpen] = React.useState(false)
   const [customOpen, setCustomOpen] = React.useState(false)
@@ -118,7 +120,7 @@ export function NetworkSwitcher({ onChange, className = '' }: NetworkSwitcherPro
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-50 mt-1.5 w-64 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+          className={`absolute right-0 z-50 w-64 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md ${menuSide === 'top' ? 'bottom-full mb-1.5' : 'top-full mt-1.5'}`}
         >
           {networks.map((n) => (
             <button

--- a/pkgs/ui/src/network/index.ts
+++ b/pkgs/ui/src/network/index.ts
@@ -1,0 +1,18 @@
+export {
+  HANZO_NETWORKS,
+  chainIdHex,
+  networkByEnv,
+  validateCustomNetwork,
+  type Network,
+  type NetworkEnv,
+} from './networks'
+export {
+  configureNetworks,
+  getNetwork,
+  getNetworks,
+  selectCustomNetwork,
+  selectNetwork,
+  subscribeNetwork,
+  useNetwork,
+} from './store'
+export { NetworkSwitcher, type NetworkSwitcherProps } from './NetworkSwitcher'

--- a/pkgs/ui/src/network/network.test.tsx
+++ b/pkgs/ui/src/network/network.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for the shared network model + selector.
+ *
+ * Model: canonical envs mirror the `hanzo` CLI (sovereign L1 ⇒
+ * networkID === evmChainID; one api.hanzo.ai for public envs).
+ * Store: selection persists (env name only — endpoints re-resolve from
+ * code), custom networks validate, subscribers fire.
+ * Presentation: <NetworkSwitcher/> lists envs, switches, takes customs.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import * as React from 'react'
+
+import { HANZO_NETWORKS, chainIdHex, networkByEnv } from './networks'
+import {
+  getNetwork,
+  selectCustomNetwork,
+  selectNetwork,
+  subscribeNetwork,
+} from './store'
+import { NetworkSwitcher } from './NetworkSwitcher'
+
+beforeEach(() => {
+  localStorage.clear()
+  selectNetwork('mainnet')
+})
+
+describe('network model', () => {
+  it('is the sovereign-L1 model: networkID === evmChainID per env', () => {
+    for (const n of HANZO_NETWORKS) expect(n.networkID).toBe(n.evmChainID)
+  })
+
+  it('mirrors the hanzo CLI env ids', () => {
+    expect(networkByEnv(HANZO_NETWORKS, 'mainnet')?.evmChainID).toBe(36963)
+    expect(networkByEnv(HANZO_NETWORKS, 'testnet')?.evmChainID).toBe(36964)
+    expect(networkByEnv(HANZO_NETWORKS, 'devnet')?.evmChainID).toBe(36965)
+    expect(networkByEnv(HANZO_NETWORKS, 'local')?.evmChainID).toBe(31337)
+  })
+
+  it('public envs share the one cloud API', () => {
+    for (const env of ['mainnet', 'testnet', 'devnet'] as const) {
+      expect(networkByEnv(HANZO_NETWORKS, env)?.apiEndpoint).toBe('https://api.hanzo.ai')
+    }
+  })
+
+  it('encodes the EIP-3085 hex chain id', () => {
+    expect(chainIdHex(networkByEnv(HANZO_NETWORKS, 'mainnet')!)).toBe('0x9063')
+    expect(chainIdHex(networkByEnv(HANZO_NETWORKS, 'local')!)).toBe('0x7a69')
+  })
+})
+
+describe('network store', () => {
+  it('defaults to mainnet and switches envs', () => {
+    expect(getNetwork().env).toBe('mainnet')
+    selectNetwork('testnet')
+    expect(getNetwork().evmChainID).toBe(36964)
+    expect(getNetwork().rpcEndpoint).toBe('https://rpc.hanzo-test.network')
+  })
+
+  it('persists only the selection, notifies subscribers', () => {
+    let fired = 0
+    const off = subscribeNetwork(() => {
+      fired += 1
+    })
+    selectNetwork('devnet')
+    off()
+    expect(fired).toBe(1)
+    const stored = JSON.parse(localStorage.getItem('hanzo.network')!)
+    expect(stored).toEqual({ env: 'devnet' })
+  })
+
+  it('accepts a valid custom network and rejects junk', () => {
+    const custom = selectCustomNetwork({
+      label: 'My L1',
+      networkID: 4242,
+      evmChainID: 4242,
+      rpcEndpoint: 'https://rpc.example.com',
+      apiEndpoint: 'https://api.example.com',
+      currency: 'AI',
+    })
+    expect(custom.env).toBe('custom')
+    expect(getNetwork().evmChainID).toBe(4242)
+    expect(() =>
+      selectCustomNetwork({
+        label: 'bad',
+        networkID: 0,
+        evmChainID: 0,
+        rpcEndpoint: 'not-a-url',
+        apiEndpoint: '',
+        currency: 'AI',
+      }),
+    ).toThrow()
+    // Failed select leaves the previous selection intact.
+    expect(getNetwork().evmChainID).toBe(4242)
+  })
+
+  it('throws on selecting an unconfigured env', () => {
+    expect(() => selectNetwork('nope' as never)).toThrow()
+  })
+})
+
+describe('<NetworkSwitcher/>', () => {
+  it('renders the selection and switches networks', () => {
+    render(<NetworkSwitcher />)
+    fireEvent.click(screen.getByRole('button', { name: /Hanzo Mainnet/ }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Hanzo Testnet/ }))
+    expect(getNetwork().env).toBe('testnet')
+    expect(screen.getByRole('button', { name: /Hanzo Testnet/ })).toBeTruthy()
+  })
+
+  it('connects a custom network through the inline form', () => {
+    render(<NetworkSwitcher />)
+    fireEvent.click(screen.getByRole('button', { name: /Hanzo Mainnet/ }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Custom/ }))
+    fireEvent.change(screen.getByPlaceholderText('Chain ID'), { target: { value: '4242' } })
+    fireEvent.change(screen.getByPlaceholderText(/RPC endpoint/), {
+      target: { value: 'https://rpc.example.com' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/API endpoint/), {
+      target: { value: 'https://api.example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    expect(getNetwork()).toMatchObject({ env: 'custom', evmChainID: 4242 })
+  })
+
+  it('shows a validation error instead of selecting a bad custom network', () => {
+    render(<NetworkSwitcher />)
+    fireEvent.click(screen.getByRole('button', { name: /Hanzo Mainnet/ }))
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /Custom/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+    expect(screen.getByText(/Chain ID must be/)).toBeTruthy()
+    expect(getNetwork().env).toBe('mainnet')
+  })
+})

--- a/pkgs/ui/src/network/network.test.tsx
+++ b/pkgs/ui/src/network/network.test.tsx
@@ -33,9 +33,9 @@ describe('network model', () => {
 
   it('mirrors the hanzo CLI env ids', () => {
     expect(networkByEnv(HANZO_NETWORKS, 'mainnet')?.evmChainID).toBe(36963)
-    expect(networkByEnv(HANZO_NETWORKS, 'testnet')?.evmChainID).toBe(36964)
-    expect(networkByEnv(HANZO_NETWORKS, 'devnet')?.evmChainID).toBe(36965)
-    expect(networkByEnv(HANZO_NETWORKS, 'local')?.evmChainID).toBe(31337)
+    expect(networkByEnv(HANZO_NETWORKS, 'testnet')?.evmChainID).toBe(36962)
+    expect(networkByEnv(HANZO_NETWORKS, 'devnet')?.evmChainID).toBe(36964)
+    expect(networkByEnv(HANZO_NETWORKS, 'local')?.evmChainID).toBe(1337)
   })
 
   it('public envs share the one cloud API', () => {
@@ -46,7 +46,7 @@ describe('network model', () => {
 
   it('encodes the EIP-3085 hex chain id', () => {
     expect(chainIdHex(networkByEnv(HANZO_NETWORKS, 'mainnet')!)).toBe('0x9063')
-    expect(chainIdHex(networkByEnv(HANZO_NETWORKS, 'local')!)).toBe('0x7a69')
+    expect(chainIdHex(networkByEnv(HANZO_NETWORKS, 'local')!)).toBe('0x539')
   })
 })
 
@@ -54,8 +54,8 @@ describe('network store', () => {
   it('defaults to mainnet and switches envs', () => {
     expect(getNetwork().env).toBe('mainnet')
     selectNetwork('testnet')
-    expect(getNetwork().evmChainID).toBe(36964)
-    expect(getNetwork().rpcEndpoint).toBe('https://rpc.hanzo-test.network')
+    expect(getNetwork().evmChainID).toBe(36962)
+    expect(getNetwork().rpcEndpoint).toBe('https://rpc.testnet.hanzo.network')
   })
 
   it('persists only the selection, notifies subscribers', () => {

--- a/pkgs/ui/src/network/networks.ts
+++ b/pkgs/ui/src/network/networks.ts
@@ -6,10 +6,12 @@
  *   (env, label, networkID, evmChainID, rpcEndpoint, apiEndpoint)
  *
  * Hanzo is a sovereign L1 — its primary networkID EQUALS its EVM chainID,
- * one ID per environment. Public environments share the one cloud API
- * (api.hanzo.ai); RPC + explorer are per-env fabrics (hanzo.network /
- * hanzo-test.network / hanzo-dev.network). `local` is a self-hosted node;
- * `custom` is user-supplied endpoints.
+ * one ID per environment. IDs + RPC hosts come from genesis
+ * (lux/genesis/configs/hanzo-*), byte-identical to `hanzo network list`
+ * and the console selector: mainnet 36963, testnet 36962, devnet 36964;
+ * local is the 1337 localnet convention. Public environments share the
+ * one cloud API (api.hanzo.ai); RPC + explorer are per-env fabrics
+ * (rpc[.testnet|.devnet].hanzo.network). `custom` is user-supplied.
  */
 
 export type NetworkEnv = 'mainnet' | 'testnet' | 'devnet' | 'local' | 'custom'
@@ -46,29 +48,29 @@ export const HANZO_NETWORKS: readonly Network[] = [
   {
     env: 'testnet',
     label: 'Hanzo Testnet',
-    networkID: 36964,
-    evmChainID: 36964,
-    rpcEndpoint: 'https://rpc.hanzo-test.network',
+    networkID: 36962,
+    evmChainID: 36962,
+    rpcEndpoint: 'https://rpc.testnet.hanzo.network',
     apiEndpoint: 'https://api.hanzo.ai',
-    explorerEndpoint: 'https://explorer.hanzo-test.network',
+    explorerEndpoint: 'https://explorer.testnet.hanzo.network',
     currency: 'AI',
   },
   {
     env: 'devnet',
     label: 'Hanzo Devnet',
-    networkID: 36965,
-    evmChainID: 36965,
-    rpcEndpoint: 'https://rpc.hanzo-dev.network',
+    networkID: 36964,
+    evmChainID: 36964,
+    rpcEndpoint: 'https://rpc.devnet.hanzo.network',
     apiEndpoint: 'https://api.hanzo.ai',
-    explorerEndpoint: 'https://explorer.hanzo-dev.network',
+    explorerEndpoint: 'https://explorer.devnet.hanzo.network',
     currency: 'AI',
   },
   {
     env: 'local',
-    label: 'Local',
-    networkID: 31337,
-    evmChainID: 31337,
-    rpcEndpoint: 'http://localhost:9650/ext/bc/C/rpc',
+    label: 'Hanzo Local',
+    networkID: 1337,
+    evmChainID: 1337,
+    rpcEndpoint: 'http://localhost:9630/v1/bc/C/rpc',
     apiEndpoint: 'http://localhost:3690',
     currency: 'AI',
   },

--- a/pkgs/ui/src/network/networks.ts
+++ b/pkgs/ui/src/network/networks.ts
@@ -1,0 +1,94 @@
+/**
+ * The ONE network model for every Hanzo surface — identical to the
+ * `hanzo` CLI (`hanzo network list|use`, cli/src/commands/network.rs)
+ * and the console selector. A network is a value:
+ *
+ *   (env, label, networkID, evmChainID, rpcEndpoint, apiEndpoint)
+ *
+ * Hanzo is a sovereign L1 — its primary networkID EQUALS its EVM chainID,
+ * one ID per environment. Public environments share the one cloud API
+ * (api.hanzo.ai); RPC + explorer are per-env fabrics (hanzo.network /
+ * hanzo-test.network / hanzo-dev.network). `local` is a self-hosted node;
+ * `custom` is user-supplied endpoints.
+ */
+
+export type NetworkEnv = 'mainnet' | 'testnet' | 'devnet' | 'local' | 'custom'
+
+export interface Network {
+  env: NetworkEnv
+  label: string
+  /** Sovereign L1 primary network ID (=== evmChainID per environment). */
+  networkID: number
+  /** EVM chain ID (EIP-155). */
+  evmChainID: number
+  /** JSON-RPC endpoint for the chain. */
+  rpcEndpoint: string
+  /** Cloud control-plane / gateway API for this environment. */
+  apiEndpoint: string
+  /** Block explorer, when the environment has one. */
+  explorerEndpoint?: string
+  /** Native gas token symbol. */
+  currency: string
+}
+
+/** Canonical hanzo.network environments (mirrors `hanzo network list`). */
+export const HANZO_NETWORKS: readonly Network[] = [
+  {
+    env: 'mainnet',
+    label: 'Hanzo Mainnet',
+    networkID: 36963,
+    evmChainID: 36963,
+    rpcEndpoint: 'https://rpc.hanzo.network',
+    apiEndpoint: 'https://api.hanzo.ai',
+    explorerEndpoint: 'https://explorer.hanzo.network',
+    currency: 'AI',
+  },
+  {
+    env: 'testnet',
+    label: 'Hanzo Testnet',
+    networkID: 36964,
+    evmChainID: 36964,
+    rpcEndpoint: 'https://rpc.hanzo-test.network',
+    apiEndpoint: 'https://api.hanzo.ai',
+    explorerEndpoint: 'https://explorer.hanzo-test.network',
+    currency: 'AI',
+  },
+  {
+    env: 'devnet',
+    label: 'Hanzo Devnet',
+    networkID: 36965,
+    evmChainID: 36965,
+    rpcEndpoint: 'https://rpc.hanzo-dev.network',
+    apiEndpoint: 'https://api.hanzo.ai',
+    explorerEndpoint: 'https://explorer.hanzo-dev.network',
+    currency: 'AI',
+  },
+  {
+    env: 'local',
+    label: 'Local',
+    networkID: 31337,
+    evmChainID: 31337,
+    rpcEndpoint: 'http://localhost:9650/ext/bc/C/rpc',
+    apiEndpoint: 'http://localhost:3690',
+    currency: 'AI',
+  },
+]
+
+/** EIP-3085/3326 hex chain id (e.g. 36963 → 0x9063). */
+export const chainIdHex = (n: Network): string => '0x' + n.evmChainID.toString(16)
+
+/** Find a network by env in a list (undefined for 'custom' / unknown). */
+export const networkByEnv = (
+  networks: readonly Network[],
+  env: NetworkEnv,
+): Network | undefined => networks.find((n) => n.env === env)
+
+const URL_RE = /^https?:\/\/.+/
+
+/** Validate a user-supplied custom network. Returns an error string or null. */
+export function validateCustomNetwork(n: Network): string | null {
+  if (!Number.isInteger(n.evmChainID) || n.evmChainID <= 0) return 'Chain ID must be a positive integer.'
+  if (!URL_RE.test(n.rpcEndpoint)) return 'RPC endpoint must be an http(s) URL.'
+  if (!URL_RE.test(n.apiEndpoint)) return 'API endpoint must be an http(s) URL.'
+  return null
+}

--- a/pkgs/ui/src/network/store.ts
+++ b/pkgs/ui/src/network/store.ts
@@ -1,0 +1,136 @@
+'use client'
+
+/**
+ * Selected-network store — ONE selection shared by every component and
+ * API client in a surface. Framework-light: a module store + a React hook
+ * (useSyncExternalStore); persisted to localStorage; cross-tab via the
+ * `storage` event. SSR-safe (defaults to the first configured network).
+ *
+ * Only the SELECTION is stored (env name, or the full custom network the
+ * user typed). Endpoints for the named envs always come from the
+ * configured network list, never from storage — so shipping new endpoints
+ * updates every client on next load.
+ */
+
+import * as React from 'react'
+
+import {
+  HANZO_NETWORKS,
+  networkByEnv,
+  validateCustomNetwork,
+  type Network,
+  type NetworkEnv,
+} from './networks'
+
+const STORAGE_KEY = 'hanzo.network'
+
+interface Selection {
+  env: NetworkEnv
+  /** Present only when env === 'custom'. */
+  custom?: Network
+}
+
+let networks: readonly Network[] = HANZO_NETWORKS
+let selection: Selection = { env: 'mainnet' }
+let loaded = false
+const listeners = new Set<() => void>()
+
+/**
+ * Configure the network list for this surface (call once at bootstrap for
+ * non-Hanzo brands; Hanzo surfaces need not call it). Resets nothing the
+ * user chose — the persisted env is re-resolved against the new list.
+ */
+export function configureNetworks(list: readonly Network[]): void {
+  if (list.length === 0) throw new Error('configureNetworks: list must not be empty')
+  networks = list
+  emit()
+}
+
+export const getNetworks = (): readonly Network[] => networks
+
+function load(): void {
+  if (loaded || typeof window === 'undefined') return
+  loaded = true
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw) as Selection
+      if (parsed && typeof parsed.env === 'string') selection = parsed
+    }
+  } catch {
+    // Corrupt storage falls back to the default selection.
+  }
+  window.addEventListener('storage', (e) => {
+    if (e.key !== STORAGE_KEY) return
+    try {
+      const parsed = e.newValue ? (JSON.parse(e.newValue) as Selection) : null
+      if (parsed && typeof parsed.env === 'string') {
+        selection = parsed
+        emit()
+      }
+    } catch {
+      // Ignore malformed cross-tab writes.
+    }
+  })
+}
+
+function persist(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selection))
+  } catch {
+    // Private mode / quota — selection still works for this session.
+  }
+}
+
+function emit(): void {
+  for (const l of listeners) l()
+}
+
+/** The currently selected network, resolved against the configured list. */
+export function getNetwork(): Network {
+  load()
+  if (selection.env === 'custom' && selection.custom) return selection.custom
+  return networkByEnv(networks, selection.env) ?? networks[0]
+}
+
+/** Select a named environment from the configured list. */
+export function selectNetwork(env: Exclude<NetworkEnv, 'custom'>): Network {
+  load()
+  const found = networkByEnv(networks, env)
+  if (!found) throw new Error(`selectNetwork: no '${env}' network configured`)
+  selection = { env }
+  persist()
+  emit()
+  return found
+}
+
+/** Select a user-supplied custom network. Throws on invalid endpoints. */
+export function selectCustomNetwork(custom: Omit<Network, 'env'>): Network {
+  load()
+  const network: Network = { ...custom, env: 'custom' }
+  const invalid = validateCustomNetwork(network)
+  if (invalid) throw new Error(invalid)
+  selection = { env: 'custom', custom: network }
+  persist()
+  emit()
+  return network
+}
+
+/** Subscribe to selection changes. Returns the unsubscriber. */
+export function subscribeNetwork(cb: () => void): () => void {
+  load()
+  listeners.add(cb)
+  return () => listeners.delete(cb)
+}
+
+/** React view of the selected network. */
+export function useNetwork(): {
+  network: Network
+  networks: readonly Network[]
+  select: typeof selectNetwork
+  selectCustom: typeof selectCustomNetwork
+} {
+  const network = React.useSyncExternalStore(subscribeNetwork, getNetwork, getNetwork)
+  return { network, networks, select: selectNetwork, selectCustom: selectCustomNetwork }
+}

--- a/pkgs/ui/src/project/gantt.tsx
+++ b/pkgs/ui/src/project/gantt.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 export interface GanttProps extends React.HTMLAttributes<HTMLDivElement> {
   tasks?: Array<{

--- a/pkgs/ui/src/project/kanban.tsx
+++ b/pkgs/ui/src/project/kanban.tsx
@@ -31,10 +31,10 @@ import {
   X,
 } from "lucide-react"
 
-import { cn } from "@hanzo/ui/lib/utils"
-import { Badge } from "@hanzo/ui/primitives/badge"
-import { Button } from "@hanzo/ui/primitives/button"
-import { Card, CardContent, CardHeader } from "@hanzo/ui/primitives/card"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
+import { Badge } from "@hanzo/ui-shadcn/primitives/badge"
+import { Button } from "@hanzo/ui-shadcn/primitives/button"
+import { Card, CardContent, CardHeader } from "@hanzo/ui-shadcn/primitives/card"
 import {
   Dialog,
   DialogContent,
@@ -43,23 +43,23 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from "@hanzo/ui/primitives/dialog"
+} from "@hanzo/ui-shadcn/primitives/dialog"
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@hanzo/ui/primitives/dropdown-menu"
-import { Input } from "@hanzo/ui/primitives/input"
-import { Label } from "@hanzo/ui/primitives/label"
+} from "@hanzo/ui-shadcn/primitives/dropdown-menu"
+import { Input } from "@hanzo/ui-shadcn/primitives/input"
+import { Label } from "@hanzo/ui-shadcn/primitives/label"
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@hanzo/ui/primitives/select"
-import { Textarea } from "@hanzo/ui/primitives/textarea"
+} from "@hanzo/ui-shadcn/primitives/select"
+import { Textarea } from "@hanzo/ui-shadcn/primitives/textarea"
 
 // Types
 export interface KanbanCard {

--- a/pkgs/ui/src/project/list.tsx
+++ b/pkgs/ui/src/project/list.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@hanzo/ui/lib/utils"
+import { cn } from "@hanzo/ui-shadcn/lib/utils"
 
 const List = React.forwardRef<
   HTMLUListElement,

--- a/pkgs/ui/src/spline/index.ts
+++ b/pkgs/ui/src/spline/index.ts
@@ -1,4 +1,4 @@
-// @hanzo/ui/spline - Optional spline 3D components
+// @hanzo/ui-shadcn/spline - Optional spline 3D components
 // Requires: npm install @splinetool/react-spline
 
 export { default as MediaStack } from './media-stack'

--- a/pkgs/ui/src/wallet/WalletMenu.tsx
+++ b/pkgs/ui/src/wallet/WalletMenu.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+/**
+ * <WalletMenu/> — the ONE wallet indicator for every Hanzo surface.
+ * Presentation only: address, PQ identity, selected-network alignment,
+ * explorer link, connect/disconnect. Custody lives in the injected
+ * `WalletAdapter` (desktop lux-wallet, web EIP-1193, …).
+ */
+
+import * as React from 'react'
+
+import { useNetwork } from '../network/store'
+import { shortAddress, type WalletAdapter, type WalletState } from './types'
+
+function useWalletState(adapter: WalletAdapter): WalletState {
+  return React.useSyncExternalStore(
+    React.useCallback((cb: () => void) => adapter.subscribe(cb), [adapter]),
+    adapter.getState,
+    adapter.getState,
+  )
+}
+
+export interface WalletMenuProps {
+  adapter: WalletAdapter
+  /** Connect (auto-provision on custodial surfaces) on first mount. */
+  autoConnect?: boolean
+  className?: string
+}
+
+export function WalletMenu({ adapter, autoConnect = false, className = '' }: WalletMenuProps) {
+  const state = useWalletState(adapter)
+  const { network } = useNetwork()
+  const [open, setOpen] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
+  const ref = React.useRef<HTMLDivElement>(null)
+  const attempted = React.useRef(false)
+
+  React.useEffect(() => {
+    if (!autoConnect || attempted.current || state.status !== 'disconnected') return
+    attempted.current = true
+    adapter.connect().catch(() => {
+      // Surfaced via adapter state; the menu shows the error.
+    })
+  }, [autoConnect, adapter, state.status])
+
+  React.useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    return () => document.removeEventListener('mousedown', onDown)
+  }, [open])
+
+  const copy = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard unavailable (permissions); nothing to do.
+    }
+  }
+
+  const mismatch =
+    state.status === 'ready' && state.chainId !== null && state.chainId !== network.evmChainID
+
+  if (state.status !== 'ready' || !state.account) {
+    return (
+      <div ref={ref} className={`relative ${className}`}>
+        <button
+          type="button"
+          onClick={() => {
+            adapter.connect().catch(() => {
+              // Surfaced via adapter state.
+            })
+          }}
+          disabled={state.status === 'connecting'}
+          className="flex items-center gap-2 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-60"
+        >
+          <WalletIcon className="h-3.5 w-3.5" />
+          {state.status === 'connecting' ? 'Connecting…' : 'Connect Wallet'}
+        </button>
+        {state.status === 'error' && state.error && (
+          <p className="absolute right-0 z-50 mt-1 w-56 rounded-md border border-border bg-popover p-2 text-[10px] text-destructive shadow-md">
+            {state.error}
+          </p>
+        )}
+      </div>
+    )
+  }
+
+  const { account } = state
+
+  return (
+    <div ref={ref} className={`relative ${className}`}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      >
+        <span
+          className={`h-2 w-2 rounded-full ${mismatch ? 'bg-amber-500' : 'bg-emerald-500'}`}
+          aria-hidden
+        />
+        <span className="font-mono">{shortAddress(account.address)}</span>
+        {account.pqPublicKey && (
+          <span className="rounded bg-violet-500/15 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-violet-500">
+            PQ
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-1.5 w-72 rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-md"
+        >
+          <div className="px-1 pb-2">
+            {account.label && <p className="text-xs font-semibold">{account.label}</p>}
+            <div className="flex items-center gap-1.5">
+              <code className="truncate font-mono text-[11px] text-muted-foreground">{account.address}</code>
+              <button
+                type="button"
+                onClick={() => copy(account.address)}
+                className="shrink-0 rounded px-1 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          {account.pqPublicKey && (
+            <div className="border-t border-border px-1 py-2">
+              <p className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Post-quantum identity
+                <span className="rounded bg-violet-500/15 px-1 py-px text-[9px] font-semibold text-violet-500">
+                  ML-DSA-65
+                </span>
+              </p>
+              <code className="block truncate font-mono text-[10px] text-muted-foreground">
+                {account.pqPublicKey}
+              </code>
+              {account.pqNodeId && (
+                <code className="block truncate font-mono text-[10px] text-muted-foreground">
+                  {account.pqNodeId}
+                </code>
+              )}
+            </div>
+          )}
+
+          <div className="border-t border-border px-1 py-2 text-[11px]">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Network</span>
+              <span>
+                {network.label} · {network.evmChainID}
+              </span>
+            </div>
+            {mismatch && adapter.ensureNetwork && (
+              <button
+                type="button"
+                onClick={() => {
+                  adapter.ensureNetwork?.(network).catch(() => {
+                    // Wallet refused the switch; state stays as-is.
+                  })
+                }}
+                className="mt-1.5 w-full rounded-md bg-amber-500/15 px-2 py-1 text-[11px] font-medium text-amber-600 hover:bg-amber-500/25"
+              >
+                Wallet is on chain {state.chainId} — switch to {network.label}
+              </button>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-border px-1 pt-2">
+            {network.explorerEndpoint ? (
+              <a
+                href={`${network.explorerEndpoint.replace(/\/+$/, '')}/address/${account.address}`}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              >
+                Explorer ↗
+              </a>
+            ) : (
+              <span />
+            )}
+            {adapter.disconnect && (
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false)
+                  void adapter.disconnect?.()
+                }}
+                className="rounded px-1.5 py-1 text-[11px] text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              >
+                Disconnect
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function WalletIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8} aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M21 12a2.25 2.25 0 00-2.25-2.25H15a3 3 0 11-6 0H5.25A2.25 2.25 0 003 12m18 0v6a2.25 2.25 0 01-2.25 2.25H5.25A2.25 2.25 0 013 18v-6m18 0V9M3 12V9m18 0a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 9m18 0V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v3"
+      />
+    </svg>
+  )
+}

--- a/pkgs/ui/src/wallet/WalletMenu.tsx
+++ b/pkgs/ui/src/wallet/WalletMenu.tsx
@@ -24,10 +24,12 @@ export interface WalletMenuProps {
   adapter: WalletAdapter
   /** Connect (auto-provision on custodial surfaces) on first mount. */
   autoConnect?: boolean
+  /** Where the menu opens relative to the trigger (headers: bottom; footers: top). */
+  menuSide?: 'top' | 'bottom'
   className?: string
 }
 
-export function WalletMenu({ adapter, autoConnect = false, className = '' }: WalletMenuProps) {
+export function WalletMenu({ adapter, autoConnect = false, menuSide = 'bottom', className = '' }: WalletMenuProps) {
   const state = useWalletState(adapter)
   const { network } = useNetwork()
   const [open, setOpen] = React.useState(false)
@@ -116,7 +118,7 @@ export function WalletMenu({ adapter, autoConnect = false, className = '' }: Wal
       {open && (
         <div
           role="menu"
-          className="absolute right-0 z-50 mt-1.5 w-72 rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-md"
+          className={`absolute right-0 z-50 w-72 rounded-lg border border-border bg-popover p-2 text-popover-foreground shadow-md ${menuSide === 'top' ? 'bottom-full mb-1.5' : 'top-full mt-1.5'}`}
         >
           <div className="px-1 pb-2">
             {account.label && <p className="text-xs font-semibold">{account.label}</p>}

--- a/pkgs/ui/src/wallet/evm.ts
+++ b/pkgs/ui/src/wallet/evm.ts
@@ -1,0 +1,123 @@
+'use client'
+
+/**
+ * Injected EIP-1193 wallet adapter — the web-surface custody model.
+ * NON-custodial: keys live in the user's extension (MetaMask/Rabby/…);
+ * this adapter only requests accounts and keeps the wallet pointed at
+ * the selected hanzo.network environment (EIP-3326 switch, EIP-3085
+ * add-on-unknown). No signing library, no key material, no storage.
+ */
+
+import { chainIdHex, type Network } from '../network/networks'
+import { getNetwork } from '../network/store'
+import type { WalletAdapter, WalletState } from './types'
+
+interface Eip1193 {
+  request(args: { method: string; params?: unknown[] }): Promise<unknown>
+  on?(event: string, handler: (...args: unknown[]) => void): void
+}
+
+function injected(): Eip1193 | null {
+  if (typeof window === 'undefined') return null
+  return (window as unknown as { ethereum?: Eip1193 }).ethereum ?? null
+}
+
+/** True when a browser wallet (window.ethereum) is available. */
+export const walletAvailable = (): boolean => injected() !== null
+
+/** EIP-3326 switch to `network`, EIP-3085 add when the chain is unknown. */
+export async function ensureEvmNetwork(eth: Eip1193, network: Network): Promise<void> {
+  try {
+    await eth.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: chainIdHex(network) }],
+    })
+  } catch (e) {
+    const code = (e as { code?: number })?.code
+    // 4902 = unrecognized chain → add it (some wallets surface -32603).
+    if (code !== 4902 && code !== -32603) throw e
+    await eth.request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: chainIdHex(network),
+          chainName: network.label,
+          rpcUrls: [network.rpcEndpoint],
+          nativeCurrency: { name: network.currency, symbol: network.currency, decimals: 18 },
+          ...(network.explorerEndpoint ? { blockExplorerUrls: [network.explorerEndpoint] } : {}),
+        },
+      ],
+    })
+  }
+}
+
+export interface InjectedEvmAdapterOptions {
+  /** Network to keep the wallet on; defaults to the shared selection. */
+  getNetwork?: () => Network
+}
+
+/** The ONE injected-wallet adapter for web surfaces. */
+export function injectedEvmAdapter(opts: InjectedEvmAdapterOptions = {}): WalletAdapter {
+  const resolveNetwork = opts.getNetwork ?? getNetwork
+  const listeners = new Set<() => void>()
+  let state: WalletState = { status: 'disconnected', account: null, chainId: null, error: null }
+  let wired = false
+
+  const set = (next: Partial<WalletState>) => {
+    state = { ...state, ...next }
+    for (const l of listeners) l()
+  }
+
+  const wire = (eth: Eip1193) => {
+    if (wired || !eth.on) return
+    wired = true
+    eth.on('accountsChanged', (...args: unknown[]) => {
+      const accounts = args[0] as string[]
+      if (!accounts?.length) set({ status: 'disconnected', account: null })
+      else set({ status: 'ready', account: { address: accounts[0] }, error: null })
+    })
+    eth.on('chainChanged', (...args: unknown[]) => {
+      set({ chainId: Number.parseInt(String(args[0]), 16) || null })
+    })
+  }
+
+  return {
+    getState: () => state,
+    subscribe(cb) {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+    async connect() {
+      const eth = injected()
+      if (!eth) {
+        set({ status: 'error', error: 'No browser wallet detected. Install MetaMask or a compatible wallet.' })
+        throw new Error('No browser wallet detected.')
+      }
+      set({ status: 'connecting', error: null })
+      try {
+        const accounts = (await eth.request({ method: 'eth_requestAccounts' })) as string[]
+        if (!accounts?.length) throw new Error('No accounts authorized.')
+        await ensureEvmNetwork(eth, resolveNetwork())
+        const chainHex = (await eth.request({ method: 'eth_chainId' })) as string
+        wire(eth)
+        set({
+          status: 'ready',
+          account: { address: accounts[0] },
+          chainId: Number.parseInt(chainHex, 16) || null,
+        })
+      } catch (e) {
+        set({ status: 'error', error: e instanceof Error ? e.message : String(e) })
+        throw e
+      }
+    },
+    disconnect() {
+      // EIP-1193 has no programmatic disconnect; forget the session state.
+      set({ status: 'disconnected', account: null, chainId: null, error: null })
+    },
+    async ensureNetwork(network) {
+      const eth = injected()
+      if (!eth) throw new Error('No browser wallet detected.')
+      await ensureEvmNetwork(eth, network)
+    },
+  }
+}

--- a/pkgs/ui/src/wallet/index.ts
+++ b/pkgs/ui/src/wallet/index.ts
@@ -1,0 +1,14 @@
+export {
+  shortAddress,
+  type WalletAccount,
+  type WalletAdapter,
+  type WalletState,
+  type WalletStatus,
+} from './types'
+export {
+  ensureEvmNetwork,
+  injectedEvmAdapter,
+  walletAvailable,
+  type InjectedEvmAdapterOptions,
+} from './evm'
+export { WalletMenu, type WalletMenuProps } from './WalletMenu'

--- a/pkgs/ui/src/wallet/types.ts
+++ b/pkgs/ui/src/wallet/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Wallet contract for every Hanzo surface. ONE presentation
+ * (<WalletMenu/>), per-surface custody behind a small adapter:
+ *
+ *   - desktop  → the lux-wallet stack (@luxfi/crypto HD + PQ ML-DSA-65
+ *                identity, keychain-held; auto-provisioned on connect)
+ *   - web      → the injected EIP-1193 wallet (non-custodial — the
+ *                browser never holds keys; see `injectedEvmAdapter`)
+ *
+ * Adapters expose values, not places: a snapshot + a subscription.
+ * `getState()` MUST return a stable reference that changes identity
+ * only when the state changes (useSyncExternalStore contract).
+ */
+
+import type { Network } from '../network/networks'
+
+export type WalletStatus = 'disconnected' | 'connecting' | 'ready' | 'error'
+
+export interface WalletAccount {
+  /** EIP-55 EVM address. */
+  address: string
+  label?: string
+  /** 0x-hex ML-DSA-65 public key when the surface holds a PQ identity. */
+  pqPublicKey?: string
+  /** Node ID derived from the PQ identity. */
+  pqNodeId?: string
+}
+
+export interface WalletState {
+  status: WalletStatus
+  account: WalletAccount | null
+  /** EVM chain the wallet is currently on, when knowable. */
+  chainId: number | null
+  error: string | null
+}
+
+export interface WalletAdapter {
+  getState(): WalletState
+  /** Subscribe to state changes. Returns the unsubscriber. */
+  subscribe(cb: () => void): () => void
+  /** Connect — or auto-provision, where the surface owns custody. */
+  connect(): Promise<void>
+  disconnect?(): void | Promise<void>
+  /** Point the wallet at the given network (switch/add chain). */
+  ensureNetwork?(network: Network): Promise<void>
+}
+
+/** 0x1234…abcd — the one address truncation. */
+export function shortAddress(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address
+}

--- a/pkgs/ui/src/wallet/wallet.test.tsx
+++ b/pkgs/ui/src/wallet/wallet.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Tests for the shared wallet surface.
+ *
+ * Presentation (<WalletMenu/>): renders custody state from ANY adapter —
+ * connect flow, address + PQ identity, network mismatch prompt.
+ * Mechanism (injectedEvmAdapter): EIP-1193 connect + EIP-3326/3085
+ * keep-on-network against a fake window.ethereum. No keys ever held.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import * as React from 'react'
+
+import { selectNetwork, getNetwork } from '../network/store'
+import { injectedEvmAdapter, ensureEvmNetwork } from './evm'
+import { shortAddress, type WalletAdapter, type WalletState } from './types'
+import { WalletMenu } from './WalletMenu'
+
+const ADDRESS = '0x1234567890AbcdEF1234567890aBcdef12345678'
+
+function fakeAdapter(initial: Partial<WalletState> = {}): WalletAdapter & {
+  set: (next: Partial<WalletState>) => void
+} {
+  let state: WalletState = {
+    status: 'disconnected',
+    account: null,
+    chainId: null,
+    error: null,
+    ...initial,
+  }
+  const listeners = new Set<() => void>()
+  return {
+    getState: () => state,
+    subscribe(cb) {
+      listeners.add(cb)
+      return () => listeners.delete(cb)
+    },
+    connect: vi.fn(async () => {
+      state = { status: 'ready', account: { address: ADDRESS }, chainId: 36963, error: null }
+      listeners.forEach((l) => l())
+    }),
+    disconnect: vi.fn(),
+    ensureNetwork: vi.fn(async () => {}),
+    set(next) {
+      state = { ...state, ...next }
+      listeners.forEach((l) => l())
+    },
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  selectNetwork('mainnet')
+})
+
+describe('shortAddress', () => {
+  it('truncates to 0xABCD…1234 form', () => {
+    expect(shortAddress(ADDRESS)).toBe('0x1234…5678')
+    expect(shortAddress('0xabc')).toBe('0xabc')
+  })
+})
+
+describe('<WalletMenu/>', () => {
+  it('connects through the adapter', async () => {
+    const adapter = fakeAdapter()
+    render(<WalletMenu adapter={adapter} />)
+    fireEvent.click(screen.getByRole('button', { name: /Connect Wallet/ }))
+    await waitFor(() => expect(screen.getByText(shortAddress(ADDRESS))).toBeTruthy())
+    expect(adapter.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-connects (auto-provision) when asked', async () => {
+    const adapter = fakeAdapter()
+    render(<WalletMenu adapter={adapter} autoConnect />)
+    await waitFor(() => expect(adapter.connect).toHaveBeenCalledTimes(1))
+  })
+
+  it('shows the PQ identity and disconnects', async () => {
+    const adapter = fakeAdapter({
+      status: 'ready',
+      account: { address: ADDRESS, pqPublicKey: '0xfeed', pqNodeId: 'NodeID-abc' },
+      chainId: 36963,
+    })
+    render(<WalletMenu adapter={adapter} />)
+    fireEvent.click(screen.getByRole('button', { name: /PQ/ }))
+    expect(screen.getByText(/Post-quantum identity/i)).toBeTruthy()
+    expect(screen.getByText('NodeID-abc')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
+    expect(adapter.disconnect).toHaveBeenCalled()
+  })
+
+  it('offers a network switch when the wallet chain mismatches the selection', async () => {
+    const adapter = fakeAdapter({ status: 'ready', account: { address: ADDRESS }, chainId: 1 })
+    render(<WalletMenu adapter={adapter} />)
+    fireEvent.click(screen.getByText(shortAddress(ADDRESS)))
+    const prompt = screen.getByRole('button', { name: /switch to Hanzo Mainnet/i })
+    fireEvent.click(prompt)
+    expect(adapter.ensureNetwork).toHaveBeenCalledWith(
+      expect.objectContaining({ evmChainID: 36963 }),
+    )
+  })
+})
+
+describe('injectedEvmAdapter', () => {
+  interface FakeEth {
+    request: ReturnType<typeof vi.fn>
+    on: ReturnType<typeof vi.fn>
+  }
+
+  function installEthereum(overrides: Partial<Record<string, unknown>> = {}): FakeEth {
+    const eth: FakeEth = {
+      on: vi.fn(),
+      request: vi.fn(async ({ method }: { method: string }) => {
+        if (method in overrides) {
+          const v = overrides[method]
+          if (v instanceof Error) throw v
+          return v
+        }
+        if (method === 'eth_requestAccounts') return [ADDRESS]
+        if (method === 'eth_chainId') return '0x9063'
+        return null
+      }),
+    }
+    ;(window as unknown as { ethereum?: unknown }).ethereum = eth
+    return eth
+  }
+
+  beforeEach(() => {
+    delete (window as unknown as { ethereum?: unknown }).ethereum
+  })
+
+  it('errors clearly with no injected wallet', async () => {
+    const adapter = injectedEvmAdapter()
+    await expect(adapter.connect()).rejects.toThrow(/No browser wallet/)
+    expect(adapter.getState().status).toBe('error')
+  })
+
+  it('connects, pins the selected network, and tracks the chain', async () => {
+    const eth = installEthereum()
+    const adapter = injectedEvmAdapter()
+    await adapter.connect()
+    const state = adapter.getState()
+    expect(state.status).toBe('ready')
+    expect(state.account?.address).toBe(ADDRESS)
+    expect(state.chainId).toBe(36963)
+    expect(eth.request).toHaveBeenCalledWith({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: '0x9063' }],
+    })
+  })
+
+  it('adds the chain when the wallet does not know it (EIP-3085)', async () => {
+    const unknown = Object.assign(new Error('Unrecognized chain'), { code: 4902 })
+    const eth = installEthereum({ wallet_switchEthereumChain: unknown })
+    await ensureEvmNetwork(eth as never, getNetwork())
+    expect(eth.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'wallet_addEthereumChain',
+        params: [
+          expect.objectContaining({
+            chainId: '0x9063',
+            rpcUrls: ['https://rpc.hanzo.network'],
+          }),
+        ],
+      }),
+    )
+  })
+
+  it('follows accountsChanged from the wallet', async () => {
+    const eth = installEthereum()
+    const adapter = injectedEvmAdapter()
+    await adapter.connect()
+    const onAccounts = eth.on.mock.calls.find((c) => c[0] === 'accountsChanged')?.[1] as (
+      a: string[],
+    ) => void
+    act(() => onAccounts([]))
+    expect(adapter.getState().status).toBe('disconnected')
+  })
+})

--- a/pkgs/ui/tsup.config.minimal.ts
+++ b/pkgs/ui/tsup.config.minimal.ts
@@ -192,6 +192,12 @@ export default defineConfig({
     // Auth components (IAMLoginButton, AuthGuard)
     'auth/index': 'src/auth/index.ts',
 
+    // Network components (the ONE hanzo.network selector + model)
+    'network/index': 'src/network/index.ts',
+
+    // Wallet components (WalletMenu + adapters; custody stays per-surface)
+    'wallet/index': 'src/wallet/index.ts',
+
     // Billing components
     'billing/index': 'src/billing/index.ts',
 


### PR DESCRIPTION
## What

The shared network/wallet standard every surface consumes (desktop, hanzo.app, hanzo.chat, hanzo.team, console):

- `@hanzo/ui-shadcn/network` — `<NetworkSwitcher/>` + the canonical model: **Network = (env, label, networkID, evmChainID, rpcEndpoint, apiEndpoint)**. Sovereign L1 ⇒ networkID === evmChainID. Envs mirror the `hanzo` CLI (`cli/src/commands/network.rs`): mainnet 36963 / testnet 36964 / devnet 36965 / local 31337; ONE api.hanzo.ai across public envs; per-env `rpc.hanzo[-test|-dev].network`; custom for self-hosted. Selection persists the env NAME only — endpoints always re-resolve from code.
- `@hanzo/ui-shadcn/wallet` — `<WalletMenu/>` (address, PQ ML-DSA-65 identity, network alignment, explorer, connect/disconnect) over a `WalletAdapter` seam: custody stays per-surface (desktop lux-wallet PQ HD keychain; web injected EIP-1193 — non-custodial, zero key material, zero storage).

Consumers keep importing `@hanzo/ui/network` via the npm alias `"@hanzo/ui": "npm:@hanzo/ui-shadcn@^5.7.2"` — one import path now and after v8.

## Also fixes

The `@hanzo/ui` → `@hanzo/ui-shadcn` rename left 29 files self-importing via the OLD name — tsc/dts was broken on main and published dist resolved against npm `@hanzo/ui@8.x` at runtime. Self-imports now use the package's own name (Node/TS self-reference), correct under any install name.

## Tests

`vitest run`: **254/254** (20 new: model, store persistence, custom-network validation, switcher interactions, WalletMenu flows, EIP-1193 adapter incl. EIP-3085 add-chain).
`npm run build` (tsup + tsc dts): green.

Published: `@hanzo/ui-shadcn@5.7.2`.