### PR TITLE
feat(canvas): @hanzo/canvas — Railway-grade PaaS project canvas

### DIFF
--- a/.changeset/canvas-project-paas.md
+++ b/.changeset/canvas-project-paas.md
@@ -1,0 +1,13 @@
+---
+"@hanzo/canvas": minor
+---
+
+feat: new `@hanzo/canvas` package — a Railway-grade PaaS project canvas.
+
+A pannable/zoomable board of service nodes (`ProjectCanvas`) with live status
+(`ServiceStatusBadge`), metric sparklines (`MetricSparkline`), deploy timelines
+(`DeployTimeline`), an environment switcher (`EnvSwitcher`), and a service detail
+drawer (`ServiceDetailDrawer`), plus the `ServiceNode` card and `SourceRef` /
+`ReplicaPill` primitives. Presentational and data-prop-driven, built on
+`@hanzo/gui` (brand/white-label aware via the design tokens) with an optional
+`@xyflow/react` peer. Pure folds (status/layout/time) are unit-tested.

--- a/pkgs/canvas/README.md
+++ b/pkgs/canvas/README.md
@@ -1,0 +1,73 @@
+# @hanzo/canvas
+
+A **Railway-grade PaaS project canvas** for any Hanzo console — a pannable /
+zoomable board of service nodes with live status, metric sparklines, deploy
+timelines, an environment switcher, and a service detail drawer.
+
+Built on [`@hanzo/gui`](https://github.com/hanzoai/ui) (so it is **brand /
+white-label aware** via the design tokens — the same components render in the
+Hanzo, Lux, and Zoo consoles in each brand) with an optional
+[`@xyflow/react`](https://reactflow.dev) peer for the canvas itself.
+
+Every component is **presentational and data-prop-driven**: the host fetches its
+`/v1` rows and maps them into the plain view-models in `./types`. The pure folds
+(status normalization, layout, relative time) are unit-tested in isolation; the
+components never reach into a data layer. One way to do everything, decomplected.
+
+## Install
+
+```sh
+pnpm add @hanzo/canvas
+# peers: @hanzo/gui, react, react-dom, and (for the canvas) @xyflow/react
+```
+
+## The pieces
+
+| Export | What it is |
+| --- | --- |
+| `ProjectCanvas` | The pan/zoom board (React Flow): dot-grid, minimap, controls, auto-layout, theme-aware. Dynamic-import with SSR disabled. |
+| `ServiceNode` | The layered service card — icon, name, type + `/v1` capability, status badge, source ref, replicas, latest-deploy time, metric sparkline. |
+| `ServiceStatusBadge` | Status pill (dot + label) with a live pulse for `active`/`deploying`. |
+| `MetricSparkline` | A tiny honest sparkline (flat baseline when there is no data — never a fake trend). |
+| `DeployTimeline` | A vertical deploy/build timeline. |
+| `EnvSwitcher` | A segmented environment switcher (production / preview / …). |
+| `ServiceDetailDrawer` | A right-side drawer with a service header + host-supplied tabs (Deployments, Variables, Metrics, Logs, Domains, SBOM). |
+| `SourceRef`, `ReplicaPill` | Small primitives — a repo/image source ref and a replica-count pill. |
+| `normalizeServiceStatus`, `layoutGraph`, `relativeTime`, `toEpochMs`, `statusColors`, `withAlpha`, `kindLabel` | Pure helpers the host maps its data through. |
+
+## Usage
+
+```tsx
+import dynamic from 'next/dynamic'
+import { type ServiceNodeData } from '@hanzo/canvas'
+
+// The canvas touches browser globals at import — load it client-side only.
+const ProjectCanvas = dynamic(
+  () => import('@hanzo/canvas').then((m) => m.ProjectCanvas),
+  { ssr: false },
+)
+
+const nodes: ServiceNodeData[] = apps.map((a) => ({
+  id: a.id,
+  name: a.name,
+  kind: 'app',
+  status: normalizeServiceStatus(a.phase ?? a.status),
+  source: { kind: 'image', ref: `${a.image.repository}:${a.image.tag}` },
+  replicas: a.replicas,
+  deployedAt: toEpochMs(a.updatedAt),
+  capability: { id: 'platform', label: 'App Platform' },
+}))
+
+<ProjectCanvas
+  nodes={nodes}
+  edges={edges}
+  theme={resolvedTheme}
+  reducedMotion={reducedMotion}
+  onOpenDetail={(svc) => setSelected(svc)}
+/>
+```
+
+Status colors are **semantic, not brand** (green = active, amber = deploying,
+red = crashed, …) and overridable per brand via the `statusPalette` prop; all
+card chrome uses the neutral design tokens, so the canvas takes on each brand's
+theme automatically.

--- a/pkgs/canvas/gui.config.ts
+++ b/pkgs/canvas/gui.config.ts
@@ -1,0 +1,17 @@
+// Gui config for @hanzo/data typechecking.
+//
+// The canonical v5 default config — the same shape Hanzo's admin SPAs use, so
+// the shorthand style props (`bg`, `p`, `items`, `justify`, `rounded`, …) the
+// field/table components use typecheck against the real Gui token unions.
+// Consumers supply their own config + theme at runtime; this exists so the
+// library type-checks standalone. The config-type registration lives in
+// `gui.d.ts` (augmenting `@hanzogui/web`), matching the console pattern.
+
+import { createGui } from "@hanzo/gui"
+import { defaultConfig } from "@hanzogui/config/v5"
+
+export const config = createGui(defaultConfig)
+
+export default config
+
+export type Conf = typeof config

--- a/pkgs/canvas/gui.d.ts
+++ b/pkgs/canvas/gui.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Registers our Gui config with the type system so component style props
+ * (tokens, themes, shorthands) are typed. `GuiCustomConfig` is declared in
+ * `@hanzogui/web` and re-exported across the Gui packages; augmenting it there
+ * flows the types through every `@hanzo/gui` component.
+ */
+import type { Conf } from "./gui.config"
+
+declare module "@hanzogui/web" {
+  interface GuiCustomConfig extends Conf {}
+}

--- a/pkgs/canvas/package.json
+++ b/pkgs/canvas/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@hanzo/canvas",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Railway-grade PaaS project canvas — a pannable/zoomable board of service nodes with live status, metric sparklines, deploy timelines, an environment switcher, and a service detail drawer. Host-agnostic @hanzo/gui React surface, brand/white-label aware, shared by every Hanzo console (hanzo/lux/zoo).",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./pure": {
+      "types": "./src/pure.ts",
+      "default": "./src/pure.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "sideEffects": false,
+  "files": [
+    "src",
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hanzoai/ui.git",
+    "directory": "pkgs/canvas"
+  },
+  "keywords": [
+    "paas",
+    "canvas",
+    "railway",
+    "service-map",
+    "deployments",
+    "dashboard",
+    "hanzo",
+    "hanzo-ai",
+    "hanzoai",
+    "gui",
+    "react"
+  ],
+  "scripts": {
+    "tc": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc --outDir dist --declaration --emitDeclarationOnly false --module ESNext --moduleResolution bundler --jsx react-jsx --esModuleInterop true --skipLibCheck true --sourceMap true",
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "@hanzo/gui": ">=7.2.2",
+    "@xyflow/react": ">=12",
+    "react": ">=19",
+    "react-dom": ">=19"
+  },
+  "peerDependenciesMeta": {
+    "@xyflow/react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@hanzo/gui": "7.3.0",
+    "@hanzogui/config": "7.3.0",
+    "@hanzogui/web": "7.3.0",
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "@xyflow/react": "^12.11.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Hanzo AI <dev@hanzo.ai>"
+}

--- a/pkgs/canvas/src/DeployTimeline.tsx
+++ b/pkgs/canvas/src/DeployTimeline.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+/**
+ * A vertical deploy/build timeline — one dot-and-rail row per event, colored by
+ * its normalized status, newest first. Honest empty state when there are no
+ * events. Pure presentation over `DeployEvent[]`.
+ */
+import { Text, XStack, YStack } from "@hanzo/gui"
+
+import { normalizeServiceStatus, statusColors, statusLabel } from "./status"
+import { relativeTime } from "./time"
+import type { DeployEvent, ServiceStatus, StatusPalette } from "./types"
+
+export interface DeployTimelineProps {
+  events: DeployEvent[]
+  statusPalette?: Partial<Record<ServiceStatus, StatusPalette>>
+  now?: number
+  emptyLabel?: string
+}
+
+export function DeployTimeline({
+  events,
+  statusPalette,
+  now,
+  emptyLabel = "No deployments yet.",
+}: DeployTimelineProps) {
+  if (!events.length) {
+    return (
+      <Text fontSize="$2" color="$color10">
+        {emptyLabel}
+      </Text>
+    )
+  }
+  return (
+    <YStack>
+      {events.map((e, i) => {
+        const st = normalizeServiceStatus(String(e.status))
+        const c = statusColors(st, statusPalette)
+        const last = i === events.length - 1
+        return (
+          <XStack key={e.id} gap="$3" minW={0}>
+            {/* Rail */}
+            <YStack items="center" width={12} style={{ flexShrink: 0 }}>
+              <YStack
+                width={10}
+                height={10}
+                rounded={999}
+                style={{ background: c.dot, marginTop: 3 }}
+              />
+              {!last ? (
+                <YStack
+                  flex={1}
+                  width={2}
+                  bg="$color4"
+                  style={{ minHeight: 20 }}
+                />
+              ) : null}
+            </YStack>
+            <YStack flex={1} minW={0} pb={last ? "$0" : "$3"} gap="$0.5">
+              <XStack items="center" gap="$2" minW={0}>
+                <Text
+                  fontSize="$3"
+                  fontWeight="600"
+                  color="$color12"
+                  numberOfLines={1}
+                >
+                  {e.ref ?? statusLabel(st)}
+                </Text>
+                <Text
+                  fontSize="$1"
+                  fontWeight="700"
+                  style={{ color: c.fg, textTransform: "capitalize" }}
+                >
+                  {statusLabel(st)}
+                </Text>
+                <YStack flex={1} />
+                {e.createdAt ? (
+                  <Text fontSize="$1" color="$color9" numberOfLines={1}>
+                    {relativeTime(e.createdAt, now)}
+                  </Text>
+                ) : null}
+              </XStack>
+              {e.source || e.message ? (
+                <Text fontSize="$1" color="$color10" numberOfLines={2}>
+                  {[e.source, e.message].filter(Boolean).join(" · ")}
+                </Text>
+              ) : null}
+            </YStack>
+          </XStack>
+        )
+      })}
+    </YStack>
+  )
+}

--- a/pkgs/canvas/src/EnvSwitcher.tsx
+++ b/pkgs/canvas/src/EnvSwitcher.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+/**
+ * A segmented environment switcher (production / preview / …). Controlled: the
+ * host owns `value` and re-scopes its data on `onChange`. Neutral design tokens
+ * only, so it renders in any brand.
+ */
+import { Text, XStack } from "@hanzo/gui"
+
+import type { EnvOption } from "./types"
+
+export interface EnvSwitcherProps {
+  options: EnvOption[]
+  value: string
+  onChange: (id: string) => void
+  size?: "sm" | "md"
+}
+
+export function EnvSwitcher({
+  options,
+  value,
+  onChange,
+  size = "md",
+}: EnvSwitcherProps) {
+  const fs = size === "sm" ? "$1" : "$2"
+  return (
+    <XStack
+      items="center"
+      gap="$1"
+      p="$1"
+      rounded="$4"
+      bg="$color2"
+      borderWidth={1}
+      borderColor="$borderColor"
+      style={{ flexShrink: 0 }}
+    >
+      {options.map((o) => {
+        const active = o.id === value
+        return (
+          <XStack
+            key={o.id}
+            items="center"
+            gap="$1.5"
+            px="$2.5"
+            py="$1.5"
+            rounded="$3"
+            bg={active ? "$color1" : "transparent"}
+            borderWidth={1}
+            borderColor={active ? "$borderColor" : "transparent"}
+            hoverStyle={active ? undefined : { bg: "$color3" }}
+            onPress={() => onChange(o.id)}
+            style={{
+              cursor: "pointer",
+              boxShadow: active ? "0 1px 2px rgba(0,0,0,0.12)" : undefined,
+            }}
+          >
+            <Text
+              fontSize={fs}
+              fontWeight={active ? "700" : "500"}
+              color={active ? "$color12" : "$color10"}
+            >
+              {o.label}
+            </Text>
+            {o.count != null ? (
+              <XStack
+                bg={active ? "$color4" : "$color3"}
+                px="$1.5"
+                rounded={999}
+                items="center"
+              >
+                <Text fontSize="$1" color="$color11" fontWeight="600">
+                  {o.count}
+                </Text>
+              </XStack>
+            ) : null}
+          </XStack>
+        )
+      })}
+    </XStack>
+  )
+}

--- a/pkgs/canvas/src/MetricSparkline.tsx
+++ b/pkgs/canvas/src/MetricSparkline.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+/**
+ * A tiny inline-SVG sparkline for the metric preview on a service card. Pure and
+ * honest: with fewer than two points it renders a flat dashed baseline (a real
+ * "no data yet" signal), never a fabricated trend.
+ */
+import type { CSSProperties } from "react"
+
+export interface MetricSparklineProps {
+  points: number[]
+  width?: number
+  height?: number
+  stroke?: string
+  strokeWidth?: number
+  /** Area fill under the line (e.g. a translucent version of `stroke`). */
+  fill?: string | null
+  min?: number
+  max?: number
+  style?: CSSProperties
+}
+
+export function MetricSparkline({
+  points,
+  width = 76,
+  height = 24,
+  stroke = "#8b949e",
+  strokeWidth = 1.5,
+  fill = null,
+  min,
+  max,
+  style,
+}: MetricSparklineProps) {
+  const n = points.length
+  if (n < 2) {
+    return (
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        style={style}
+        aria-hidden
+      >
+        <line
+          x1={0}
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          stroke={stroke}
+          strokeWidth={1}
+          strokeDasharray="2 3"
+          opacity={0.5}
+        />
+      </svg>
+    )
+  }
+  const lo = min ?? Math.min(...points)
+  const hi = max ?? Math.max(...points)
+  const span = hi - lo || 1
+  const pad = strokeWidth
+  const innerH = height - pad * 2
+  const stepX = width / (n - 1)
+  const coords = points.map((p, i) => {
+    const x = i * stepX
+    const y = pad + innerH - ((p - lo) / span) * innerH
+    return [x, y] as const
+  })
+  const line = coords
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(" ")
+  const area = fill
+    ? `${line} L${width.toFixed(2)},${height} L0,${height} Z`
+    : ""
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      style={style}
+      aria-hidden
+    >
+      {fill ? <path d={area} fill={fill} stroke="none" /> : null}
+      <path
+        d={line}
+        fill="none"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/pkgs/canvas/src/ProjectCanvas.tsx
+++ b/pkgs/canvas/src/ProjectCanvas.tsx
@@ -1,0 +1,220 @@
+"use client"
+
+/**
+ * The project canvas — a pannable/zoomable board of service nodes and the honest
+ * connections between them (Railway-style). Read-only: positions come from the
+ * deterministic auto-layout (or explicit `positions`), nodes are draggable for
+ * exploration but never connectable, edges are computed, not drawn.
+ *
+ * Browser-only (`@xyflow/react` touches globals at import) — a host should
+ * dynamic-import this with SSR disabled. Theme-aware: the chrome + edge/dot hues
+ * follow the `theme` prop (drive it off your app's resolved theme, not
+ * `prefers-color-scheme`).
+ */
+import { useCallback, useMemo } from "react"
+import type { CSSProperties } from "react"
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from "@xyflow/react"
+
+import "@xyflow/react/dist/style.css"
+
+import type { ReactNode } from "react"
+
+import { CANVAS_NODE_TYPES, CanvasNodeConfigProvider } from "./canvas-node"
+import { layoutGraph, type LayoutOptions, type XYPosition } from "./layout"
+import { statusColors } from "./status"
+import { CanvasStyles } from "./styles"
+import type {
+  ServiceEdgeData,
+  ServiceNodeData,
+  ServiceStatus,
+  StatusPalette,
+} from "./types"
+
+export interface ProjectCanvasProps {
+  nodes: ServiceNodeData[]
+  edges?: ServiceEdgeData[]
+  /** Explicit positions by node id; else the nodes are auto-laid-out. */
+  positions?: Record<string, XYPosition>
+  layoutOptions?: LayoutOptions
+  reducedMotion?: boolean
+  theme?: "light" | "dark"
+  statusPalette?: Partial<Record<ServiceStatus, StatusPalette>>
+  renderIcon?: (d: ServiceNodeData) => ReactNode
+  onSelect?: (d: ServiceNodeData | null) => void
+  onOpenDetail?: (d: ServiceNodeData) => void
+  nodeWidth?: number
+  showMiniMap?: boolean
+  showControls?: boolean
+  fitViewPadding?: number
+  /** Rendered over the canvas when there are no nodes. */
+  empty?: ReactNode
+  now?: number
+  style?: CSSProperties
+}
+
+const THEME_VARS = {
+  dark: {
+    "--hz-border": "#30363d",
+    "--hz-surface": "#0d1117",
+    "--hz-surface-2": "#161b22",
+    "--hz-fg": "#c9d1d9",
+    "--hz-edge": "#3d444d",
+    "--hz-dots": "#21262d",
+    "--hz-minimap": "rgba(1,4,9,0.6)",
+  },
+  light: {
+    "--hz-border": "#d0d7de",
+    "--hz-surface": "#ffffff",
+    "--hz-surface-2": "#f6f8fa",
+    "--hz-fg": "#57606a",
+    "--hz-edge": "#afb8c1",
+    "--hz-dots": "#d8dee4",
+    "--hz-minimap": "rgba(255,255,255,0.6)",
+  },
+} as const
+
+function toFlow(
+  nodes: ServiceNodeData[],
+  edges: ServiceEdgeData[],
+  positions: Record<string, XYPosition>,
+  animate: boolean
+): { nodes: Node[]; edges: Edge[] } {
+  const flowNodes: Node[] = nodes.map((n) => ({
+    id: n.id,
+    type: "service",
+    position: positions[n.id] ?? { x: 0, y: 0 },
+    data: n as unknown as Record<string, unknown>,
+    connectable: false,
+  }))
+  const flowEdges: Edge[] = edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    label: e.label,
+    animated: animate && (e.reason ?? "dependency") === "route",
+    style: {
+      stroke: "var(--hz-edge)",
+      strokeWidth: 1.5,
+      strokeDasharray: e.reason === "reference" ? "5 4" : undefined,
+    },
+  }))
+  return { nodes: flowNodes, edges: flowEdges }
+}
+
+export function ProjectCanvas({
+  nodes,
+  edges = [],
+  positions,
+  layoutOptions,
+  reducedMotion,
+  theme = "dark",
+  statusPalette,
+  renderIcon,
+  onSelect,
+  onOpenDetail,
+  nodeWidth,
+  showMiniMap = true,
+  showControls = true,
+  fitViewPadding = 0.24,
+  empty,
+  now,
+  style,
+}: ProjectCanvasProps) {
+  const pos = useMemo(() => {
+    if (positions) return positions
+    const laid = layoutGraph(nodes, edges, layoutOptions)
+    return Object.fromEntries(laid.map((n) => [n.id, n.position]))
+  }, [positions, nodes, edges, layoutOptions])
+
+  const { nodes: flowNodes, edges: flowEdges } = useMemo(
+    () => toFlow(nodes, edges, pos, !reducedMotion),
+    [nodes, edges, pos, reducedMotion]
+  )
+
+  const onNodeClick = useCallback<NodeMouseHandler>(
+    (_e, node) => {
+      const d = node.data as unknown as ServiceNodeData
+      onSelect?.(d)
+      onOpenDetail?.(d)
+    },
+    [onSelect, onOpenDetail]
+  )
+
+  const cfg = useMemo(
+    () => ({ renderIcon, statusPalette, reducedMotion, now, nodeWidth }),
+    [renderIcon, statusPalette, reducedMotion, now, nodeWidth]
+  )
+
+  const isEmpty = nodes.length === 0
+
+  return (
+    <div
+      className="hz-canvas"
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        ...(THEME_VARS[theme] as CSSProperties),
+        ...style,
+      }}
+    >
+      <CanvasStyles />
+      {isEmpty && empty ? (
+        <div style={{ position: "absolute", inset: 0, zIndex: 2 }}>{empty}</div>
+      ) : (
+        <CanvasNodeConfigProvider value={cfg}>
+          <ReactFlowProvider>
+            <ReactFlow
+              nodes={flowNodes}
+              edges={flowEdges}
+              nodeTypes={CANVAS_NODE_TYPES}
+              onNodeClick={onNodeClick}
+              onPaneClick={() => onSelect?.(null)}
+              fitView
+              fitViewOptions={{ padding: fitViewPadding, maxZoom: 1 }}
+              minZoom={0.2}
+              maxZoom={1.6}
+              nodesConnectable={false}
+              elementsSelectable
+              proOptions={{ hideAttribution: true }}
+              colorMode={theme}
+            >
+              <Background
+                variant={BackgroundVariant.Dots}
+                gap={18}
+                size={1}
+                color="var(--hz-dots)"
+              />
+              {showMiniMap ? (
+                <MiniMap
+                  pannable
+                  zoomable
+                  nodeStrokeWidth={0}
+                  nodeColor={(n) =>
+                    statusColors(
+                      (n.data as unknown as ServiceNodeData).status,
+                      statusPalette
+                    ).dot
+                  }
+                  maskColor="var(--hz-minimap)"
+                  style={{ background: "var(--hz-surface)" }}
+                />
+              ) : null}
+              {showControls ? <Controls showInteractive={false} /> : null}
+            </ReactFlow>
+          </ReactFlowProvider>
+        </CanvasNodeConfigProvider>
+      )}
+    </div>
+  )
+}

--- a/pkgs/canvas/src/ReplicaPill.tsx
+++ b/pkgs/canvas/src/ReplicaPill.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+/**
+ * A small neutral pill showing replica count (`3×`). Renders nothing when the
+ * count is undefined; a single replica still shows `1×` so scale is explicit.
+ */
+import { Text, XStack } from "@hanzo/gui"
+
+export interface ReplicaPillProps {
+  replicas?: number
+  size?: "sm" | "md"
+}
+
+export function ReplicaPill({ replicas, size = "md" }: ReplicaPillProps) {
+  if (replicas == null || !Number.isFinite(replicas) || replicas < 0)
+    return null
+  const fs = size === "sm" ? "$1" : "$2"
+  return (
+    <XStack
+      items="center"
+      gap="$1"
+      px="$1.5"
+      py="$0.5"
+      rounded="$2"
+      bg="$color3"
+    >
+      <Text fontSize={fs} color="$color11" fontWeight="600">
+        {replicas}×
+      </Text>
+    </XStack>
+  )
+}

--- a/pkgs/canvas/src/ServiceDetailDrawer.tsx
+++ b/pkgs/canvas/src/ServiceDetailDrawer.tsx
@@ -1,0 +1,266 @@
+"use client"
+
+/**
+ * The service detail drawer — a right-side overlay with a service header and a
+ * tab bar. The tab bodies are injected by the host (`tabs[].content`), so the
+ * drawer shell is reusable while the host owns each panel's data (Deployments,
+ * Variables, Metrics, Logs, Domains, SBOM). Self-contained: backdrop, slide-in,
+ * Escape-to-close, and a body-scroll lock — no external drawer dependency.
+ */
+import { useEffect, useState } from "react"
+import type { ReactNode } from "react"
+import { Text, XStack, YStack } from "@hanzo/gui"
+
+import { kindLabel } from "./color"
+import { kindGlyph } from "./glyphs"
+import { ServiceStatusBadge } from "./ServiceStatusBadge"
+import { CanvasStyles } from "./styles"
+import type { ServiceNodeData, ServiceStatus, StatusPalette } from "./types"
+
+const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace"
+
+export interface DrawerTab {
+  id: string
+  label: string
+  content: ReactNode
+  badge?: number | string
+}
+
+export interface ServiceDetailDrawerProps {
+  open: boolean
+  onClose: () => void
+  service: ServiceNodeData | null
+  tabs: DrawerTab[]
+  /** Controlled active tab; omit for internal (uncontrolled) tab state. */
+  activeTab?: string
+  onTabChange?: (id: string) => void
+  width?: number
+  reducedMotion?: boolean
+  statusPalette?: Partial<Record<ServiceStatus, StatusPalette>>
+  renderIcon?: (d: ServiceNodeData) => ReactNode
+  /** Extra controls in the header (e.g. a Deploy button). */
+  headerActions?: ReactNode
+  zIndex?: number
+}
+
+function CloseGlyph() {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      aria-hidden
+    >
+      <path d="M6 6l12 12M18 6 6 18" />
+    </svg>
+  )
+}
+
+export function ServiceDetailDrawer({
+  open,
+  onClose,
+  service,
+  tabs,
+  activeTab,
+  onTabChange,
+  width = 480,
+  reducedMotion,
+  statusPalette,
+  renderIcon,
+  headerActions,
+  zIndex = 1000,
+}: ServiceDetailDrawerProps) {
+  const [internal, setInternal] = useState<string | undefined>(tabs[0]?.id)
+
+  // Reset the uncontrolled tab when the drawer opens for a different service.
+  useEffect(() => {
+    if (open) setInternal(tabs[0]?.id)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, service?.id])
+
+  // Escape-to-close + body-scroll lock while open.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", onKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = "hidden"
+    return () => {
+      document.removeEventListener("keydown", onKey)
+      document.body.style.overflow = prev
+    }
+  }, [open, onClose])
+
+  if (!open || !service) return null
+
+  const active = activeTab ?? internal ?? tabs[0]?.id
+  const activePanel = tabs.find((t) => t.id === active) ?? tabs[0]
+  const Glyph = kindGlyph(service.kind)
+  const icon = renderIcon ? renderIcon(service) : <Glyph size={18} />
+
+  const selectTab = (id: string) => {
+    onTabChange?.(id)
+    setInternal(id)
+  }
+
+  return (
+    <div style={{ position: "fixed", inset: 0, zIndex }}>
+      {/* Backdrop */}
+      <div
+        className={reducedMotion ? undefined : "hz-canvas-backdrop"}
+        onClick={onClose}
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: "rgba(0,0,0,0.42)",
+        }}
+      />
+      {/* Panel */}
+      <YStack
+        className={reducedMotion ? undefined : "hz-canvas-drawer"}
+        role="dialog"
+        aria-modal
+        aria-label={`${service.name} details`}
+        bg="$color1"
+        borderLeftWidth={1}
+        borderColor="$borderColor"
+        style={{
+          position: "absolute",
+          top: 0,
+          right: 0,
+          height: "100%",
+          width: `min(100vw, ${width}px)`,
+          boxShadow: "-16px 0 48px rgba(0,0,0,0.28)",
+        }}
+      >
+        {/* Header */}
+        <YStack
+          p="$4"
+          gap="$3"
+          borderBottomWidth={1}
+          borderColor="$borderColor"
+        >
+          <XStack items="flex-start" gap="$3" minW={0}>
+            <YStack
+              width={38}
+              height={38}
+              rounded="$3"
+              items="center"
+              justify="center"
+              bg="$color3"
+              style={{ flexShrink: 0, color: "#8b949e" }}
+            >
+              <span style={{ display: "inline-flex" }}>{icon}</span>
+            </YStack>
+            <YStack flex={1} minW={0} gap="$1">
+              <Text
+                fontSize="$6"
+                fontWeight="800"
+                color="$color12"
+                numberOfLines={1}
+              >
+                {service.name}
+              </Text>
+              <XStack items="center" gap="$2" minW={0} flexWrap="wrap">
+                <Text fontSize="$2" color="$color10">
+                  {service.typeLabel ?? kindLabel(service.kind)}
+                </Text>
+                {service.capability ? (
+                  <XStack bg="$color2" px="$2" py="$0.5" rounded="$2">
+                    <Text
+                      fontSize="$1"
+                      color="$color10"
+                      style={{ fontFamily: MONO }}
+                    >
+                      {service.capability.path ??
+                        `/v1/${service.capability.id}`}
+                    </Text>
+                  </XStack>
+                ) : null}
+              </XStack>
+            </YStack>
+            <XStack
+              items="center"
+              justify="center"
+              width={30}
+              height={30}
+              rounded="$3"
+              hoverStyle={{ bg: "$color3" }}
+              onPress={onClose}
+              style={{ cursor: "pointer", color: "#8b949e", flexShrink: 0 }}
+            >
+              <span style={{ display: "inline-flex" }}>
+                <CloseGlyph />
+              </span>
+            </XStack>
+          </XStack>
+
+          <XStack items="center" gap="$2" flexWrap="wrap">
+            <ServiceStatusBadge
+              status={service.status}
+              label={service.statusLabel}
+              palette={statusPalette}
+              reducedMotion={reducedMotion}
+            />
+            {headerActions}
+          </XStack>
+        </YStack>
+
+        {/* Tab bar */}
+        <XStack
+          borderBottomWidth={1}
+          borderColor="$borderColor"
+          px="$3"
+          gap="$1"
+          style={{ overflowX: "auto", flexShrink: 0 }}
+        >
+          {tabs.map((t) => {
+            const on = t.id === active
+            return (
+              <XStack
+                key={t.id}
+                items="center"
+                gap="$1.5"
+                px="$2.5"
+                py="$2.5"
+                onPress={() => selectTab(t.id)}
+                style={{
+                  cursor: "pointer",
+                  borderBottom: `2px solid ${on ? "#8b949e" : "transparent"}`,
+                  marginBottom: -1,
+                }}
+              >
+                <Text
+                  fontSize="$2"
+                  fontWeight={on ? "700" : "500"}
+                  color={on ? "$color12" : "$color10"}
+                >
+                  {t.label}
+                </Text>
+                {t.badge != null ? (
+                  <XStack bg="$color3" px="$1.5" rounded={999} items="center">
+                    <Text fontSize="$1" color="$color11" fontWeight="600">
+                      {t.badge}
+                    </Text>
+                  </XStack>
+                ) : null}
+              </XStack>
+            )
+          })}
+        </XStack>
+
+        {/* Active panel */}
+        <YStack flex={1} p="$4" gap="$3" style={{ overflowY: "auto" }}>
+          <CanvasStyles />
+          {activePanel?.content}
+        </YStack>
+      </YStack>
+    </div>
+  )
+}

--- a/pkgs/canvas/src/ServiceNode.tsx
+++ b/pkgs/canvas/src/ServiceNode.tsx
@@ -1,0 +1,181 @@
+"use client"
+
+/**
+ * The service card — the one node the canvas renders for every service. Layered
+ * and elevated (z-depth shadow + hover lift + selected ring), it reads
+ * glanceably: a status accent bar, an icon tile, the service name, its type +
+ * `/v1` capability, its source ref, and a footer with replicas, latest-deploy
+ * relative time, and a metric sparkline preview. Pure presentation — it takes a
+ * `ServiceNodeData` and callbacks; it never fetches. Usable inside the canvas
+ * (via `canvas-node`) or standalone in a grid/list.
+ */
+import type { ReactNode } from "react"
+import { Text, XStack, YStack } from "@hanzo/gui"
+
+import { kindLabel, withAlpha } from "./color"
+import { kindGlyph } from "./glyphs"
+import { MetricSparkline } from "./MetricSparkline"
+import { ReplicaPill } from "./ReplicaPill"
+import { ServiceStatusBadge } from "./ServiceStatusBadge"
+import { SourceRef } from "./SourceRef"
+import { statusColors } from "./status"
+import { relativeTime } from "./time"
+import type { ServiceNodeData, ServiceStatus, StatusPalette } from "./types"
+
+const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace"
+
+export interface ServiceNodeProps {
+  data: ServiceNodeData
+  selected?: boolean
+  reducedMotion?: boolean
+  width?: number
+  statusPalette?: Partial<Record<ServiceStatus, StatusPalette>>
+  /** Override the icon (e.g. pass a lucide icon); default is the built-in glyph. */
+  renderIcon?: (data: ServiceNodeData) => ReactNode
+  onOpen?: (data: ServiceNodeData) => void
+  /** `now` for deterministic relative-time rendering (tests/SSR). */
+  now?: number
+}
+
+export function ServiceNode({
+  data,
+  selected,
+  reducedMotion,
+  width = 268,
+  statusPalette,
+  renderIcon,
+  onOpen,
+  now,
+}: ServiceNodeProps) {
+  const c = statusColors(data.status, statusPalette)
+  const accent = data.accent ?? c.dot
+  const tinted = !!data.accent
+  const Glyph = kindGlyph(data.kind)
+  const icon = renderIcon ? renderIcon(data) : <Glyph size={17} />
+  const deployed = relativeTime(data.deployedAt, now)
+
+  return (
+    <XStack
+      className="hz-canvas-node"
+      width={width}
+      rounded="$5"
+      bg="$color1"
+      borderWidth={1}
+      borderColor={selected ? "$color8" : "$borderColor"}
+      overflow="hidden"
+      style={{
+        boxShadow: selected
+          ? `0 0 0 1px ${accent}, 0 10px 28px rgba(0,0,0,0.20), 0 2px 6px rgba(0,0,0,0.10)`
+          : "0 1px 2px rgba(0,0,0,0.10), 0 6px 16px rgba(0,0,0,0.06)",
+        cursor: onOpen ? "pointer" : "default",
+      }}
+      onPress={onOpen ? () => onOpen(data) : undefined}
+      hoverStyle={onOpen ? { borderColor: "$color7" } : undefined}
+    >
+      {/* Status accent bar */}
+      <YStack width={3} style={{ background: accent }} />
+
+      <YStack flex={1} p="$3" gap="$2.5" minW={0}>
+        {/* Header: icon + name/type + status */}
+        <XStack items="flex-start" gap="$2.5" minW={0}>
+          <YStack
+            width={34}
+            height={34}
+            rounded="$3"
+            items="center"
+            justify="center"
+            bg={tinted ? undefined : "$color3"}
+            style={{
+              flexShrink: 0,
+              background: tinted ? withAlpha(accent, 0.14) : undefined,
+              color: tinted ? accent : "#8b949e",
+            }}
+          >
+            <span style={{ display: "inline-flex" }}>{icon}</span>
+          </YStack>
+
+          <YStack flex={1} minW={0} gap="$1">
+            <Text
+              fontSize="$4"
+              fontWeight="700"
+              color="$color12"
+              numberOfLines={1}
+            >
+              {data.name}
+            </Text>
+            <XStack items="center" gap="$1.5" minW={0} flexWrap="wrap">
+              <Text
+                fontSize="$1"
+                color="$color10"
+                numberOfLines={1}
+                style={{ flexShrink: 0 }}
+              >
+                {data.typeLabel ?? kindLabel(data.kind)}
+              </Text>
+              {data.capability ? (
+                <XStack
+                  bg="$color2"
+                  px="$1.5"
+                  py="$0.5"
+                  rounded="$2"
+                  minW={0}
+                  style={{ flexShrink: 1 }}
+                >
+                  <Text
+                    fontSize="$1"
+                    color="$color10"
+                    numberOfLines={1}
+                    style={{ fontFamily: MONO }}
+                  >
+                    {data.capability.path ?? `/v1/${data.capability.id}`}
+                  </Text>
+                </XStack>
+              ) : null}
+            </XStack>
+          </YStack>
+
+          <ServiceStatusBadge
+            status={data.status}
+            size="sm"
+            palette={statusPalette}
+            reducedMotion={reducedMotion}
+          />
+        </XStack>
+
+        {/* Source */}
+        {data.source ? <SourceRef source={data.source} size="sm" /> : null}
+
+        {/* Footer: replicas + deploy time | metric preview */}
+        <XStack items="center" justify="space-between" gap="$2" minW={0}>
+          <XStack items="center" gap="$2" minW={0}>
+            <ReplicaPill replicas={data.replicas} size="sm" />
+            {data.deployedAt ? (
+              <Text fontSize="$1" color="$color9" numberOfLines={1}>
+                {deployed}
+              </Text>
+            ) : null}
+          </XStack>
+          {data.metric ? (
+            <XStack items="center" gap="$1.5" style={{ flexShrink: 0 }}>
+              <MetricSparkline
+                points={data.metric.points}
+                width={64}
+                height={20}
+                stroke={c.dot}
+                strokeWidth={1.5}
+                fill={withAlpha(c.dot, 0.12)}
+                min={data.metric.min}
+                max={data.metric.max}
+              />
+              {data.metric.value ? (
+                <Text fontSize="$1" color="$color10" numberOfLines={1}>
+                  {data.metric.value}
+                </Text>
+              ) : null}
+            </XStack>
+          ) : null}
+        </XStack>
+      </YStack>
+    </XStack>
+  )
+}

--- a/pkgs/canvas/src/ServiceStatusBadge.tsx
+++ b/pkgs/canvas/src/ServiceStatusBadge.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+/**
+ * The status pill — a colored dot + label that reads glanceably. Semantic status
+ * colors (not brand) from the overridable palette; the `active`/`deploying` dot
+ * pulses (a live thing breathing) unless reduced motion is requested.
+ */
+import { Text, XStack } from "@hanzo/gui"
+
+import { statusColors, statusLabel, statusPulses } from "./status"
+import type { ServiceStatus, StatusPalette } from "./types"
+
+export interface ServiceStatusBadgeProps {
+  status: ServiceStatus
+  /** Override text (e.g. the raw backend lifecycle string). */
+  label?: string
+  size?: "sm" | "md"
+  showDot?: boolean
+  palette?: Partial<Record<ServiceStatus, StatusPalette>>
+  reducedMotion?: boolean
+}
+
+const SIZES = {
+  sm: { px: 6, py: 2, fs: 10, dot: 6, gap: 4 },
+  md: { px: 8, py: 3, fs: 11, dot: 7, gap: 5 },
+} as const
+
+export function ServiceStatusBadge({
+  status,
+  label,
+  size = "md",
+  showDot = true,
+  palette,
+  reducedMotion,
+}: ServiceStatusBadgeProps) {
+  const c = statusColors(status, palette)
+  const s = SIZES[size]
+  const pulse = statusPulses(status) && !reducedMotion
+  return (
+    <XStack
+      items="center"
+      gap={s.gap}
+      px={s.px}
+      py={s.py}
+      rounded={999}
+      style={{ background: c.soft }}
+    >
+      {showDot ? (
+        <span
+          className={
+            pulse ? "hz-canvas-dot hz-canvas-dot--pulse" : "hz-canvas-dot"
+          }
+          style={{
+            width: s.dot,
+            height: s.dot,
+            borderRadius: 999,
+            background: c.dot,
+            ["--hz-dot" as string]: c.dot,
+          }}
+        />
+      ) : null}
+      <Text
+        fontSize={s.fs}
+        fontWeight="700"
+        style={{ color: c.fg, letterSpacing: 0.2, textTransform: "capitalize" }}
+      >
+        {label ?? statusLabel(status)}
+      </Text>
+    </XStack>
+  )
+}

--- a/pkgs/canvas/src/SourceRef.tsx
+++ b/pkgs/canvas/src/SourceRef.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+/**
+ * A compact source reference — the repo (`owner/name` + branch), image
+ * (`repository:tag`), template, database engine, or managed origin a service
+ * ships from, with a matching glyph. Monospace ref for scannability; the text
+ * uses a neutral design token, the decorative glyph a muted neutral hue.
+ */
+import { Text, XStack } from "@hanzo/gui"
+
+import { sourceGlyph } from "./glyphs"
+import type { ServiceSource } from "./types"
+
+const MONO = "ui-monospace, SFMono-Regular, Menlo, monospace"
+
+export interface SourceRefProps {
+  source: ServiceSource
+  size?: "sm" | "md"
+}
+
+export function SourceRef({ source, size = "md" }: SourceRefProps) {
+  const Glyph = sourceGlyph(source.kind)
+  const fs = size === "sm" ? "$1" : "$2"
+  const glyphSize = size === "sm" ? 12 : 13
+  return (
+    <XStack items="center" gap="$1.5" minW={0}>
+      <span style={{ display: "inline-flex", color: "#8b949e", flexShrink: 0 }}>
+        <Glyph size={glyphSize} />
+      </span>
+      <Text
+        fontSize={fs}
+        color="$color10"
+        numberOfLines={1}
+        style={{ fontFamily: MONO }}
+        minW={0}
+      >
+        {source.ref}
+      </Text>
+      {source.branch ? (
+        <Text
+          fontSize={fs}
+          color="$color9"
+          numberOfLines={1}
+          style={{ fontFamily: MONO }}
+        >
+          {source.branch}
+        </Text>
+      ) : null}
+    </XStack>
+  )
+}

--- a/pkgs/canvas/src/canvas-node.tsx
+++ b/pkgs/canvas/src/canvas-node.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+/**
+ * The React Flow node type that renders a `ServiceNode` card. Per-render config
+ * (icon override, palette, reduced-motion, `now`) rides a context so the
+ * `nodeTypes` map stays a stable module-level identity — React Flow re-creates
+ * the graph if `nodeTypes` changes, so it must never be built inline. Handles are
+ * invisible and non-interactive: the graph is derived, never drawn by the user.
+ */
+import { createContext, memo, useContext } from "react"
+import type { CSSProperties, ReactNode } from "react"
+import { Handle, Position, type NodeProps } from "@xyflow/react"
+
+import { ServiceNode } from "./ServiceNode"
+import type { ServiceNodeData, ServiceStatus, StatusPalette } from "./types"
+
+export interface CanvasNodeConfig {
+  renderIcon?: (d: ServiceNodeData) => ReactNode
+  statusPalette?: Partial<Record<ServiceStatus, StatusPalette>>
+  reducedMotion?: boolean
+  now?: number
+  nodeWidth?: number
+}
+
+const Ctx = createContext<CanvasNodeConfig>({})
+export const CanvasNodeConfigProvider = Ctx.Provider
+
+const HANDLE: CSSProperties = {
+  opacity: 0,
+  width: 1,
+  height: 1,
+  minWidth: 1,
+  border: "none",
+  background: "transparent",
+  pointerEvents: "none",
+}
+
+const ServiceFlowNode = memo(function ServiceFlowNode({
+  data,
+  selected,
+}: NodeProps) {
+  const cfg = useContext(Ctx)
+  const d = data as unknown as ServiceNodeData
+  return (
+    <>
+      <Handle
+        type="target"
+        position={Position.Left}
+        style={HANDLE}
+        isConnectable={false}
+      />
+      <ServiceNode
+        data={d}
+        selected={selected}
+        reducedMotion={cfg.reducedMotion}
+        statusPalette={cfg.statusPalette}
+        renderIcon={cfg.renderIcon}
+        now={cfg.now}
+        width={cfg.nodeWidth}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        style={HANDLE}
+        isConnectable={false}
+      />
+    </>
+  )
+})
+
+/** Stable module-level node-type map — one card renders every service. */
+export const CANVAS_NODE_TYPES = { service: ServiceFlowNode } as const

--- a/pkgs/canvas/src/color.ts
+++ b/pkgs/canvas/src/color.ts
@@ -1,0 +1,42 @@
+/**
+ * Minimal color helpers — turn a `#rrggbb`/`#rgb` hex into an `rgba()` string so
+ * an accent can tint a soft surface. Any non-hex input (e.g. already `rgba()`)
+ * is returned unchanged.
+ */
+export function withAlpha(color: string, alpha: number): string {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(color.trim())
+  if (!m) return color
+  let hex = m[1]
+  if (hex.length === 3)
+    hex = hex
+      .split("")
+      .map((c) => c + c)
+      .join("")
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+  const a = Math.max(0, Math.min(1, alpha))
+  return `rgba(${r}, ${g}, ${b}, ${a})`
+}
+
+const KIND_LABEL: Record<string, string> = {
+  app: "App",
+  web: "Web",
+  worker: "Worker",
+  database: "Database",
+  cache: "Cache",
+  vector: "Vector",
+  search: "Search",
+  storage: "Storage",
+  queue: "Queue",
+  domain: "Domain",
+  function: "Function",
+  cron: "Cron",
+  ai: "AI",
+  service: "Service",
+}
+
+/** Human label for a service kind (falls back to a capitalized id). */
+export const kindLabel = (kind: string): string =>
+  KIND_LABEL[kind] ??
+  (kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "Service")

--- a/pkgs/canvas/src/css.d.ts
+++ b/pkgs/canvas/src/css.d.ts
@@ -1,0 +1,2 @@
+// Allow importing a stylesheet (e.g. @xyflow/react's) from a component module.
+declare module "*.css"

--- a/pkgs/canvas/src/glyphs.tsx
+++ b/pkgs/canvas/src/glyphs.tsx
@@ -1,0 +1,157 @@
+/**
+ * A compact, dependency-free inline-SVG glyph set — the standalone fallback for
+ * service-node icons and source refs. A host console typically overrides these
+ * by passing its own icon set via `renderIcon` (e.g. lucide); these exist so the
+ * package looks right with zero extra dependencies (CSP-safe, no icon lib).
+ */
+import type { ReactNode, SVGProps } from "react"
+
+import type { ServiceKind, ServiceSource } from "./types"
+
+type GlyphProps = { size?: number } & Omit<
+  SVGProps<SVGSVGElement>,
+  "width" | "height"
+>
+
+function svg(path: ReactNode) {
+  return function Glyph({ size = 16, ...rest }: GlyphProps) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.7}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+        {...rest}
+      >
+        {path}
+      </svg>
+    )
+  }
+}
+
+export const BoxGlyph = svg(
+  <>
+    <path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8" />
+    <path d="M3.3 7 12 12l8.7-5M12 22V12" />
+    <path d="M12 2 3 7l9 5 9-5-9-5Z" />
+  </>
+)
+export const GlobeGlyph = svg(
+  <>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3 12h18M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18Z" />
+  </>
+)
+export const DatabaseGlyph = svg(
+  <>
+    <ellipse cx="12" cy="5" rx="8" ry="3" />
+    <path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" />
+  </>
+)
+export const LayersGlyph = svg(
+  <>
+    <path d="m12 2 9 5-9 5-9-5 9-5Z" />
+    <path d="m3 12 9 5 9-5M3 17l9 5 9-5" />
+  </>
+)
+export const BoltGlyph = svg(<path d="M13 2 4 14h7l-1 8 9-12h-7l1-8Z" />)
+export const ServerGlyph = svg(
+  <>
+    <rect x="3" y="4" width="18" height="7" rx="1.5" />
+    <rect x="3" y="13" width="18" height="7" rx="1.5" />
+    <path d="M7 7.5h.01M7 16.5h.01" />
+  </>
+)
+export const KeyGlyph = svg(
+  <>
+    <circle cx="7.5" cy="15.5" r="4" />
+    <path d="M10.5 12.5 20 3M16 7l3 3M14 9l2 2" />
+  </>
+)
+export const SearchGlyph = svg(
+  <>
+    <circle cx="11" cy="11" r="7" />
+    <path d="m21 21-4.3-4.3" />
+  </>
+)
+export const HardDriveGlyph = svg(
+  <>
+    <path d="M22 12H2M5.5 6h13l3.5 6v6a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-6l3.5-6Z" />
+    <path d="M6 16h.01M10 16h.01" />
+  </>
+)
+export const QueueGlyph = svg(<path d="M4 6h16M4 12h16M4 18h10" />)
+export const ClockGlyph = svg(
+  <>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 2" />
+  </>
+)
+export const CpuGlyph = svg(
+  <>
+    <rect x="6" y="6" width="12" height="12" rx="2" />
+    <path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3" />
+  </>
+)
+export const GitBranchGlyph = svg(
+  <>
+    <circle cx="6" cy="6" r="2.5" />
+    <circle cx="6" cy="18" r="2.5" />
+    <circle cx="18" cy="8" r="2.5" />
+    <path d="M6 8.5v7M8.5 7.2C13 8 15.5 8 15.5 11v0" />
+  </>
+)
+export const CubeGlyph = svg(
+  <>
+    <path d="M12 2 3 7v10l9 5 9-5V7l-9-5Z" />
+    <path d="m3 7 9 5 9-5M12 22V12" />
+  </>
+)
+export const CloudGlyph = svg(
+  <path d="M6.5 19a4.5 4.5 0 0 1-.5-8.98A6 6 0 0 1 17.7 9 4 4 0 0 1 17.5 19H6.5Z" />
+)
+export const TemplateGlyph = svg(
+  <>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <path d="M3 9h18M9 21V9" />
+  </>
+)
+
+const KIND_GLYPH: Record<ServiceKind, ReturnType<typeof svg>> = {
+  app: BoxGlyph,
+  web: GlobeGlyph,
+  worker: CpuGlyph,
+  database: DatabaseGlyph,
+  cache: KeyGlyph,
+  vector: LayersGlyph,
+  search: SearchGlyph,
+  storage: HardDriveGlyph,
+  queue: QueueGlyph,
+  domain: GlobeGlyph,
+  function: BoltGlyph,
+  cron: ClockGlyph,
+  ai: CpuGlyph,
+  service: ServerGlyph,
+}
+
+/** The default glyph component for a service kind. */
+export const kindGlyph = (kind: ServiceKind): ReturnType<typeof svg> =>
+  KIND_GLYPH[kind] ?? ServerGlyph
+
+const SOURCE_GLYPH: Record<ServiceSource["kind"], ReturnType<typeof svg>> = {
+  repo: GitBranchGlyph,
+  image: CubeGlyph,
+  template: TemplateGlyph,
+  database: DatabaseGlyph,
+  managed: CloudGlyph,
+}
+
+/** The default glyph component for a source kind. */
+export const sourceGlyph = (
+  kind: ServiceSource["kind"]
+): ReturnType<typeof svg> => SOURCE_GLYPH[kind] ?? CubeGlyph

--- a/pkgs/canvas/src/index.ts
+++ b/pkgs/canvas/src/index.ts
@@ -1,0 +1,41 @@
+// @hanzo/canvas — a Railway-grade PaaS project canvas for any Hanzo console.
+//
+// A pannable/zoomable board of service nodes with live status, metric
+// sparklines, deploy timelines, an environment switcher, and a service detail
+// drawer. Every component is presentational and data-prop-driven: the host
+// fetches its `/v1` rows and maps them into the plain view-models in `./types`.
+// Built on @hanzo/gui (brand/white-label aware via the design tokens) with an
+// optional @xyflow/react peer for the canvas itself.
+//
+//   import { ProjectCanvas, ServiceNode, ServiceStatusBadge } from '@hanzo/canvas'
+
+// Data contract + pure helpers (no React) — also available React-free at
+// `@hanzo/canvas/pure` for data mappers + their unit tests.
+export * from "./pure"
+export { kindGlyph, sourceGlyph } from "./glyphs"
+
+// Presentational components
+export {
+  ServiceStatusBadge,
+  type ServiceStatusBadgeProps,
+} from "./ServiceStatusBadge"
+export { MetricSparkline, type MetricSparklineProps } from "./MetricSparkline"
+export { SourceRef, type SourceRefProps } from "./SourceRef"
+export { ReplicaPill, type ReplicaPillProps } from "./ReplicaPill"
+export { ServiceNode, type ServiceNodeProps } from "./ServiceNode"
+export { DeployTimeline, type DeployTimelineProps } from "./DeployTimeline"
+export { EnvSwitcher, type EnvSwitcherProps } from "./EnvSwitcher"
+export {
+  ServiceDetailDrawer,
+  type ServiceDetailDrawerProps,
+  type DrawerTab,
+} from "./ServiceDetailDrawer"
+export { CanvasStyles, CANVAS_CSS } from "./styles"
+
+// The canvas (pulls in @xyflow/react — dynamic-import this with SSR disabled)
+export { ProjectCanvas, type ProjectCanvasProps } from "./ProjectCanvas"
+export {
+  CANVAS_NODE_TYPES,
+  CanvasNodeConfigProvider,
+  type CanvasNodeConfig,
+} from "./canvas-node"

--- a/pkgs/canvas/src/layout.test.ts
+++ b/pkgs/canvas/src/layout.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test"
+
+import { layoutGraph } from "./layout"
+
+describe("layoutGraph", () => {
+  test("is deterministic — same graph, byte-identical positions", () => {
+    const nodes = [{ id: "a" }, { id: "b" }, { id: "c" }]
+    const edges = [{ source: "a", target: "b" }]
+    expect(layoutGraph(nodes, edges)).toEqual(layoutGraph(nodes, edges))
+  })
+
+  test("layers along edges: domain → app → resource land in columns 0,1,2", () => {
+    const nodes = [{ id: "app" }, { id: "db" }, { id: "dom" }]
+    const edges = [
+      { source: "dom", target: "app" },
+      { source: "app", target: "db" },
+    ]
+    const pos = Object.fromEntries(
+      layoutGraph(nodes, edges, { columnGap: 100, rowGap: 100 }).map((p) => [
+        p.id,
+        p.position,
+      ])
+    )
+    expect(pos.dom.x).toBe(0)
+    expect(pos.app.x).toBe(100)
+    expect(pos.db.x).toBe(200)
+  })
+
+  test("isolated nodes stack in column 0, centered", () => {
+    const nodes = [{ id: "x" }, { id: "y" }]
+    const laid = layoutGraph(nodes, [], { columnGap: 100, rowGap: 100 })
+    expect(laid.every((p) => p.position.x === 0)).toBe(true)
+    // two rows centered on axis 50 → y = 0 and 100
+    const ys = laid.map((p) => p.position.y).sort((a, b) => a - b)
+    expect(ys).toEqual([0, 100])
+  })
+
+  test("preserves input order + one position per node", () => {
+    const nodes = [{ id: "c" }, { id: "a" }, { id: "b" }]
+    const laid = layoutGraph(nodes, [])
+    expect(laid.map((p) => p.id)).toEqual(["c", "a", "b"])
+  })
+
+  test("a cycle never wedges the layout", () => {
+    const nodes = [{ id: "a" }, { id: "b" }, { id: "c" }]
+    const edges = [
+      { source: "a", target: "b" },
+      { source: "b", target: "c" },
+      { source: "c", target: "a" },
+    ]
+    const laid = layoutGraph(nodes, edges)
+    expect(laid).toHaveLength(3)
+  })
+
+  test("ignores edges referencing missing / self nodes", () => {
+    const nodes = [{ id: "a" }, { id: "b" }]
+    const edges = [
+      { source: "a", target: "ghost" },
+      { source: "b", target: "b" },
+    ]
+    const laid = layoutGraph(nodes, edges, { columnGap: 100 })
+    // no valid edge advances a column → both in column 0
+    expect(laid.every((p) => p.position.x === 0)).toBe(true)
+  })
+})

--- a/pkgs/canvas/src/layout.ts
+++ b/pkgs/canvas/src/layout.ts
@@ -1,0 +1,127 @@
+/**
+ * Deterministic layered graph layout — pure, no React, no DOM, unit-tested.
+ *
+ * Nodes are assigned to columns by longest-path layering over the edges (a
+ * source with no incoming edge sits in column 0; every other node sits one
+ * column right of its deepest parent), then stacked and vertically centered
+ * within each column on a shared axis so tiers read as clean columns — the
+ * Railway "left-to-right dependency flow" look. Isolated nodes (no edges) fall
+ * into column 0. The same graph always yields byte-identical positions.
+ */
+
+export interface XYPosition {
+  x: number
+  y: number
+}
+
+export interface PositionedId {
+  id: string
+  position: XYPosition
+}
+
+export interface LayoutOptions {
+  /** Center-to-center horizontal distance between columns. */
+  columnGap?: number
+  /** Center-to-center vertical distance between stacked nodes. */
+  rowGap?: number
+}
+
+const DEFAULTS = { columnGap: 384, rowGap: 168 } as const
+
+interface Edgeish {
+  source: string
+  target: string
+}
+interface Nodeish {
+  id: string
+}
+
+/**
+ * Assign each node a column via longest-path layering. Processes nodes in
+ * topological order (Kahn); an edge into a node with an unknown/cyclic parent
+ * degrades gracefully (the child simply keeps the max column seen so far), so a
+ * cycle can never wedge the layout.
+ */
+function assignColumns(ids: string[], edges: Edgeish[]): Map<string, number> {
+  const present = new Set(ids)
+  const outgoing = new Map<string, string[]>()
+  const indeg = new Map<string, number>()
+  for (const id of ids) {
+    outgoing.set(id, [])
+    indeg.set(id, 0)
+  }
+  for (const e of edges) {
+    if (
+      !present.has(e.source) ||
+      !present.has(e.target) ||
+      e.source === e.target
+    )
+      continue
+    outgoing.get(e.source)!.push(e.target)
+    indeg.set(e.target, (indeg.get(e.target) ?? 0) + 1)
+  }
+
+  const column = new Map<string, number>()
+  for (const id of ids) column.set(id, 0)
+
+  // Kahn queue seeded with roots (indeg 0), stable by id order.
+  const remaining = new Map(indeg)
+  const queue = ids.filter((id) => (remaining.get(id) ?? 0) === 0).sort()
+  const seen = new Set<string>()
+  while (queue.length) {
+    const u = queue.shift()!
+    if (seen.has(u)) continue
+    seen.add(u)
+    const cu = column.get(u) ?? 0
+    for (const v of outgoing.get(u) ?? []) {
+      if (cu + 1 > (column.get(v) ?? 0)) column.set(v, cu + 1)
+      const left = (remaining.get(v) ?? 0) - 1
+      remaining.set(v, left)
+      if (left <= 0 && !seen.has(v)) queue.push(v)
+    }
+    queue.sort()
+  }
+  // Any node left unprocessed (part of a cycle) keeps its best-known column.
+  return column
+}
+
+/**
+ * Position nodes into centered columns. Returns one `{ id, position }` per input
+ * node (input order preserved), with `x` by column and `y` centered per column.
+ */
+export function layoutGraph(
+  nodes: Nodeish[],
+  edges: Edgeish[],
+  opts: LayoutOptions = {}
+): PositionedId[] {
+  const columnGap = opts.columnGap ?? DEFAULTS.columnGap
+  const rowGap = opts.rowGap ?? DEFAULTS.rowGap
+  const ids = nodes.map((n) => n.id)
+  const column = assignColumns(ids, edges)
+
+  // Group node ids by column, sorted within a column for stable stacking.
+  const byColumn = new Map<number, string[]>()
+  for (const id of ids) {
+    const c = column.get(id) ?? 0
+    const list = byColumn.get(c)
+    if (list) list.push(id)
+    else byColumn.set(c, [id])
+  }
+  for (const list of byColumn.values()) list.sort()
+
+  const maxRows = Math.max(1, ...Array.from(byColumn.values(), (l) => l.length))
+  const axis = ((maxRows - 1) * rowGap) / 2
+
+  const pos = new Map<string, XYPosition>()
+  for (const [c, list] of byColumn) {
+    const top = axis - ((list.length - 1) * rowGap) / 2
+    list.forEach((id, i) =>
+      pos.set(id, { x: c * columnGap, y: top + i * rowGap })
+    )
+  }
+
+  return nodes.map((n) => ({
+    id: n.id,
+    position: pos.get(n.id) ?? { x: 0, y: 0 },
+  }))
+}

--- a/pkgs/canvas/src/pure.ts
+++ b/pkgs/canvas/src/pure.ts
@@ -1,0 +1,35 @@
+// @hanzo/canvas/pure — the React-free surface: the data contract + the pure folds
+// (status normalization, layout, relative time, color helpers). Import from here
+// (not the package root) when you only need the logic — e.g. a host's data mapper
+// and its unit tests — so you never pull in @xyflow/react or any JSX.
+
+export type {
+  ServiceStatus,
+  ServiceKind,
+  ServiceSource,
+  ServiceMetric,
+  ServiceCapability,
+  ServiceNodeData,
+  ServiceEdgeReason,
+  ServiceEdgeData,
+  DeployEvent,
+  EnvOption,
+  EnvVarRow,
+  StatusPalette,
+} from "./types"
+
+export {
+  normalizeServiceStatus,
+  statusColors,
+  statusLabel,
+  statusPulses,
+  DEFAULT_STATUS_PALETTE,
+} from "./status"
+export { relativeTime, toEpochMs } from "./time"
+export {
+  layoutGraph,
+  type LayoutOptions,
+  type PositionedId,
+  type XYPosition,
+} from "./layout"
+export { withAlpha, kindLabel } from "./color"

--- a/pkgs/canvas/src/status.test.ts
+++ b/pkgs/canvas/src/status.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  DEFAULT_STATUS_PALETTE,
+  normalizeServiceStatus,
+  statusColors,
+  statusLabel,
+  statusPulses,
+} from "./status"
+
+describe("normalizeServiceStatus", () => {
+  test("maps known active words", () => {
+    for (const w of [
+      "running",
+      "live",
+      "ready",
+      "OK",
+      "Succeeded",
+      "green",
+      "Healthy",
+    ]) {
+      expect(normalizeServiceStatus(w)).toBe("active")
+    }
+  })
+  test("maps deploying / queued / crashed / sleeping / removed", () => {
+    expect(normalizeServiceStatus("building")).toBe("deploying")
+    expect(normalizeServiceStatus("provisioning")).toBe("deploying")
+    expect(normalizeServiceStatus("queued")).toBe("queued")
+    expect(normalizeServiceStatus("pending")).toBe("queued")
+    expect(normalizeServiceStatus("failed")).toBe("crashed")
+    expect(normalizeServiceStatus("CrashLoopBackOff")).toBe("crashed")
+    expect(normalizeServiceStatus("stopped")).toBe("sleeping")
+    expect(normalizeServiceStatus("deleting")).toBe("removed")
+  })
+  test("empty / unknown is honest unknown, never guessed active", () => {
+    expect(normalizeServiceStatus("")).toBe("unknown")
+    expect(normalizeServiceStatus(undefined)).toBe("unknown")
+    expect(normalizeServiceStatus(null)).toBe("unknown")
+    expect(normalizeServiceStatus("wat")).toBe("unknown")
+  })
+  test("compound strings fall back on contained words", () => {
+    expect(normalizeServiceStatus("1/2 running")).toBe("active")
+    expect(normalizeServiceStatus("deploy in progress")).toBe("deploying")
+    expect(normalizeServiceStatus("image pull error")).toBe("crashed")
+  })
+})
+
+describe("palette + labels", () => {
+  test("statusColors honors an override, else default", () => {
+    expect(statusColors("active")).toBe(DEFAULT_STATUS_PALETTE.active)
+    const custom = { dot: "#000", fg: "#111", soft: "rgba(0,0,0,0.1)" }
+    expect(statusColors("active", { active: custom })).toBe(custom)
+    // unmapped status in override → default
+    expect(statusColors("crashed", { active: custom })).toBe(
+      DEFAULT_STATUS_PALETTE.crashed
+    )
+  })
+  test("every status has a palette + label", () => {
+    for (const s of [
+      "active",
+      "deploying",
+      "queued",
+      "crashed",
+      "sleeping",
+      "removed",
+      "unknown",
+    ] as const) {
+      expect(DEFAULT_STATUS_PALETTE[s]).toBeDefined()
+      expect(typeof statusLabel(s)).toBe("string")
+    }
+  })
+  test("only active + deploying pulse", () => {
+    expect(statusPulses("active")).toBe(true)
+    expect(statusPulses("deploying")).toBe(true)
+    expect(statusPulses("crashed")).toBe(false)
+    expect(statusPulses("sleeping")).toBe(false)
+  })
+})

--- a/pkgs/canvas/src/status.ts
+++ b/pkgs/canvas/src/status.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure status logic — the one place a free-form backend lifecycle string is
+ * folded into the small `ServiceStatus` vocabulary, plus the default semantic
+ * palette. No React, no DOM — unit-tested in isolation.
+ */
+import type { ServiceStatus, StatusPalette } from "./types"
+
+const ACTIVE = new Set([
+  "active",
+  "running",
+  "ready",
+  "live",
+  "ok",
+  "succeeded",
+  "success",
+  "connected",
+  "healthy",
+  "green",
+  "up",
+  "online",
+  "available",
+])
+const DEPLOYING = new Set([
+  "deploying",
+  "building",
+  "provisioning",
+  "creating",
+  "updating",
+  "attaching",
+  "starting",
+  "restarting",
+  "yellow",
+  "pending_deploy",
+  "uploading",
+  "initializing",
+])
+const QUEUED = new Set(["queued", "pending", "waiting", "scheduled"])
+const CRASHED = new Set([
+  "crashed",
+  "error",
+  "errored",
+  "failed",
+  "failure",
+  "degraded",
+  "down",
+  "unhealthy",
+  "crashloopbackoff",
+  "red",
+  "canceled",
+  "cancelled",
+])
+const SLEEPING = new Set([
+  "sleeping",
+  "stopped",
+  "idle",
+  "paused",
+  "scaled_to_zero",
+  "asleep",
+  "suspended",
+  "inactive",
+])
+const REMOVED = new Set([
+  "removed",
+  "removing",
+  "deleting",
+  "deleted",
+  "terminated",
+  "superseded",
+])
+
+/**
+ * Normalize any lifecycle/health string to a status tone. Exact match first,
+ * then a contained-substring fallback for compound strings (e.g. `1/2 running`).
+ * Empty/unknown is honest `unknown` — never guessed up to `active`.
+ */
+export function normalizeServiceStatus(
+  raw: string | undefined | null
+): ServiceStatus {
+  const s = (raw ?? "").toString().toLowerCase().trim()
+  if (!s) return "unknown"
+  if (ACTIVE.has(s)) return "active"
+  if (DEPLOYING.has(s)) return "deploying"
+  if (QUEUED.has(s)) return "queued"
+  if (CRASHED.has(s)) return "crashed"
+  if (SLEEPING.has(s)) return "sleeping"
+  if (REMOVED.has(s)) return "removed"
+  if (/\b(error|fail|crash|degrad)/.test(s)) return "crashed"
+  if (/\b(deploy|build|provision|creat|updat)/.test(s)) return "deploying"
+  if (/\b(running|healthy|live|active|ready)/.test(s)) return "active"
+  if (/\b(stop|idle|sleep|paus|suspend)/.test(s)) return "sleeping"
+  if (/\b(queue|pending|wait)/.test(s)) return "queued"
+  return "unknown"
+}
+
+/**
+ * Default semantic status palette — tuned to read on both light and dark
+ * surfaces (GitHub-family hues). Semantic, NOT brand; a consumer may override
+ * per brand via the `statusPalette` prop on the components.
+ */
+export const DEFAULT_STATUS_PALETTE: Record<ServiceStatus, StatusPalette> = {
+  active: { dot: "#3fb950", fg: "#2ea043", soft: "rgba(63,185,80,0.14)" },
+  deploying: { dot: "#d29922", fg: "#bb8009", soft: "rgba(210,153,34,0.16)" },
+  queued: { dot: "#539bf5", fg: "#4184e4", soft: "rgba(83,155,245,0.15)" },
+  crashed: { dot: "#f85149", fg: "#e5534b", soft: "rgba(248,81,73,0.15)" },
+  sleeping: { dot: "#8b949e", fg: "#768390", soft: "rgba(139,148,158,0.14)" },
+  removed: { dot: "#6e7681", fg: "#6e7681", soft: "rgba(110,118,129,0.13)" },
+  unknown: { dot: "#8b949e", fg: "#768390", soft: "rgba(139,148,158,0.12)" },
+}
+
+const STATUS_LABEL: Record<ServiceStatus, string> = {
+  active: "Active",
+  deploying: "Deploying",
+  queued: "Queued",
+  crashed: "Crashed",
+  sleeping: "Sleeping",
+  removed: "Removed",
+  unknown: "Unknown",
+}
+
+export const statusLabel = (s: ServiceStatus): string => STATUS_LABEL[s]
+
+/** Resolve a status → its palette entry, honoring an override map. */
+export function statusColors(
+  status: ServiceStatus,
+  override?: Partial<Record<ServiceStatus, StatusPalette>>
+): StatusPalette {
+  return override?.[status] ?? DEFAULT_STATUS_PALETTE[status]
+}
+
+/** Whether a status should pulse (a live thing breathing / in-flight). */
+export const statusPulses = (s: ServiceStatus): boolean =>
+  s === "active" || s === "deploying"

--- a/pkgs/canvas/src/styles.tsx
+++ b/pkgs/canvas/src/styles.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+/**
+ * The one place the package's keyframes + canvas/drawer chrome CSS live.
+ * `<CanvasStyles/>` injects them; every animation is disabled under
+ * `prefers-reduced-motion`, and the status-dot ring color is driven by a CSS var
+ * so the pulse matches any status hue without a second element. Rendering it more
+ * than once is harmless (the identical keyframes simply re-declare).
+ */
+
+export const CANVAS_CSS = `
+.hz-canvas-dot { display: inline-block; box-shadow: 0 0 0 0 transparent; }
+.hz-canvas-dot--pulse { animation: hz-canvas-pulse 2.4s ease-out infinite; }
+@keyframes hz-canvas-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--hz-dot, #3fb950) 55%, transparent); }
+  70%  { box-shadow: 0 0 0 5px color-mix(in srgb, var(--hz-dot, #3fb950) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 transparent; }
+}
+.hz-canvas-node { transition: transform 140ms ease, box-shadow 140ms ease, border-color 140ms ease; }
+.hz-canvas-node:hover { transform: translateY(-2px); }
+.hz-canvas-fade { animation: hz-canvas-fade 180ms ease-out both; }
+@keyframes hz-canvas-fade { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+.hz-canvas-backdrop { animation: hz-canvas-backdrop-in 160ms ease-out both; }
+@keyframes hz-canvas-backdrop-in { from { opacity: 0; } to { opacity: 1; } }
+.hz-canvas-drawer { animation: hz-canvas-drawer-in 240ms cubic-bezier(0.22, 0.61, 0.36, 1) both; }
+@keyframes hz-canvas-drawer-in { from { transform: translateX(28px); opacity: 0.3; } to { transform: none; opacity: 1; } }
+@media (prefers-reduced-motion: reduce) {
+  .hz-canvas-dot--pulse { animation: none; }
+  .hz-canvas-node { transition: none; }
+  .hz-canvas-node:hover { transform: none; }
+  .hz-canvas-fade, .hz-canvas-backdrop, .hz-canvas-drawer { animation: none; }
+}
+/* React Flow chrome tuned to the neutral design tokens (theme vars set on the wrapper). */
+.hz-canvas .react-flow__attribution { display: none; }
+.hz-canvas .react-flow__controls { box-shadow: none; border: 1px solid var(--hz-border, #30363d); border-radius: 10px; overflow: hidden; }
+.hz-canvas .react-flow__controls-button { background: var(--hz-surface, #0d1117); border-bottom: 1px solid var(--hz-border, #30363d); color: var(--hz-fg, #c9d1d9); }
+.hz-canvas .react-flow__controls-button:hover { background: var(--hz-surface-2, #161b22); }
+.hz-canvas .react-flow__controls-button svg { fill: currentColor; }
+.hz-canvas .react-flow__minimap { border: 1px solid var(--hz-border, #30363d); border-radius: 10px; overflow: hidden; }
+`
+
+export function CanvasStyles() {
+  return <style dangerouslySetInnerHTML={{ __html: CANVAS_CSS }} />
+}

--- a/pkgs/canvas/src/time.test.ts
+++ b/pkgs/canvas/src/time.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+
+import { relativeTime, toEpochMs } from "./time"
+
+const NOW = 1_700_000_000_000 // fixed reference
+
+describe("relativeTime", () => {
+  test("honest dash / now for invalid or future", () => {
+    expect(relativeTime(undefined, NOW)).toBe("—")
+    expect(relativeTime(0, NOW)).toBe("—")
+    expect(relativeTime(NaN, NOW)).toBe("—")
+    expect(relativeTime(NOW + 5000, NOW)).toBe("now")
+    expect(relativeTime(NOW - 1000, NOW)).toBe("now")
+  })
+  test("scales seconds → years", () => {
+    expect(relativeTime(NOW - 30_000, NOW)).toBe("30s ago")
+    expect(relativeTime(NOW - 5 * 60_000, NOW)).toBe("5m ago")
+    expect(relativeTime(NOW - 3 * 3_600_000, NOW)).toBe("3h ago")
+    expect(relativeTime(NOW - 4 * 86_400_000, NOW)).toBe("4d ago")
+    expect(relativeTime(NOW - 21 * 86_400_000, NOW)).toBe("3w ago")
+    expect(relativeTime(NOW - 60 * 86_400_000, NOW)).toBe("2mo ago")
+    expect(relativeTime(NOW - 800 * 86_400_000, NOW)).toBe("2y ago")
+  })
+})
+
+describe("toEpochMs", () => {
+  test("scales epoch seconds to ms, leaves ms alone", () => {
+    expect(toEpochMs(1_700_000_000)).toBe(1_700_000_000_000)
+    expect(toEpochMs(1_700_000_000_000)).toBe(1_700_000_000_000)
+  })
+  test("honest undefined for missing / non-positive", () => {
+    expect(toEpochMs(0)).toBeUndefined()
+    expect(toEpochMs(undefined)).toBeUndefined()
+    expect(toEpochMs(null)).toBeUndefined()
+  })
+})

--- a/pkgs/canvas/src/time.ts
+++ b/pkgs/canvas/src/time.ts
@@ -1,0 +1,37 @@
+/**
+ * Compact relative time — pure and deterministic given `now`. Future or invalid
+ * timestamps degrade honestly (`—` / `now`), never a fabricated duration.
+ */
+export function relativeTime(
+  epochMs: number | undefined | null,
+  now: number = Date.now()
+): string {
+  if (epochMs == null || !Number.isFinite(epochMs) || epochMs <= 0) return "—"
+  const diff = now - epochMs
+  if (diff < 0) return "now"
+  const s = Math.floor(diff / 1000)
+  if (s < 5) return "now"
+  if (s < 60) return `${s}s ago`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}d ago`
+  const w = Math.floor(d / 7)
+  if (w < 5) return `${w}w ago`
+  const mo = Math.floor(d / 30)
+  if (mo < 12) return `${mo}mo ago`
+  const y = Math.floor(d / 365)
+  return `${y}y ago`
+}
+
+/**
+ * Coerce a backend timestamp to epoch **ms**. Hanzo `/v1` rows report epoch
+ * SECONDS (int64) while JS uses ms; a value below ~year-2001-in-ms is treated as
+ * seconds and scaled. `0`/absent → `undefined` (honest "no time").
+ */
+export function toEpochMs(v: number | undefined | null): number | undefined {
+  if (v == null || !Number.isFinite(v) || v <= 0) return undefined
+  return v < 1e12 ? Math.round(v * 1000) : Math.round(v)
+}

--- a/pkgs/canvas/src/types.ts
+++ b/pkgs/canvas/src/types.ts
@@ -1,0 +1,152 @@
+/**
+ * @hanzo/canvas — the data contract.
+ *
+ * Every component in this package is presentational and data-prop-driven: the
+ * host (a Hanzo console) fetches its `/v1` rows and maps them into these plain,
+ * React-free view-models. This is the ONE place the shapes live, so the pure
+ * folds (status, layout, time) are unit-tested in isolation and the visual
+ * components never reach back into a data layer.
+ */
+
+/**
+ * A service's live lifecycle, normalized to one small, glanceable vocabulary
+ * (Railway-style). `unknown` is honest — a missing signal is never guessed up
+ * to `active`.
+ */
+export type ServiceStatus =
+  | "active" // running / live / healthy
+  | "deploying" // deploying / building / provisioning
+  | "queued" // queued / pending
+  | "crashed" // error / failed / degraded
+  | "sleeping" // stopped / idle / scaled-to-zero
+  | "removed" // deleting / removed
+  | "unknown" // no signal
+
+/** What a node represents — drives the default glyph + accent tint. */
+export type ServiceKind =
+  | "app"
+  | "web"
+  | "worker"
+  | "database"
+  | "cache"
+  | "vector"
+  | "search"
+  | "storage"
+  | "queue"
+  | "domain"
+  | "function"
+  | "cron"
+  | "ai"
+  | "service"
+
+/** Where a service's code/image comes from. */
+export interface ServiceSource {
+  kind: "repo" | "image" | "template" | "database" | "managed"
+  /** repo → `owner/name`; image → `repository:tag`; database → engine; … */
+  ref: string
+  /** git branch, when `kind === 'repo'`. */
+  branch?: string
+}
+
+/**
+ * A tiny time-series preview for the card (CPU / mem / requests). `points` may
+ * be empty — the sparkline then renders an honest flat baseline, never a
+ * fabricated trend.
+ */
+export interface ServiceMetric {
+  label: string
+  points: number[]
+  /** Current formatted value, e.g. `42%` or `1.2k`. */
+  value?: string
+  /** Optional scale pins; else derived from `points`. */
+  min?: number
+  max?: number
+}
+
+/** The `/v1/<id>` Hanzo capability a node exposes (e.g. vector → `/v1/vector`). */
+export interface ServiceCapability {
+  id: string // 'vector'
+  label: string // 'Vector'
+  path?: string // '/v1/vector'
+}
+
+/**
+ * Everything a ServiceNode card needs — pure data, no back-references, no React.
+ * The console maps each `/v1` app/resource row into one of these.
+ */
+export interface ServiceNodeData {
+  id: string
+  name: string
+  kind: ServiceKind
+  status: ServiceStatus
+  /** Raw lifecycle string the backend reported (shown verbatim in the drawer). */
+  statusLabel?: string
+  /** Short type label under the name, e.g. `App`, `PostgreSQL`, `Domain`. */
+  typeLabel?: string
+  source?: ServiceSource
+  replicas?: number
+  /** Epoch **ms** of the latest deploy — rendered as relative time. */
+  deployedAt?: number
+  metric?: ServiceMetric
+  capability?: ServiceCapability
+  region?: string
+  /** In-app deep link opened by the node's primary action. */
+  href?: string
+  /** External URL (a domain's live site). */
+  externalHref?: string
+  /** Optional accent hex to tint the node (else derived from status). */
+  accent?: string
+}
+
+/**
+ * Why an edge exists — keeps the graph honest and drives the edge style:
+ * `route` (a domain fronting an app, solid + animated), `reference` (a link
+ * derived from an env var, dashed), `dependency` (a declared link, solid).
+ */
+export type ServiceEdgeReason = "route" | "reference" | "dependency"
+
+export interface ServiceEdgeData {
+  id: string
+  source: string
+  target: string
+  reason?: ServiceEdgeReason
+  label?: string
+}
+
+/** A deploy/build event for the DeployTimeline. */
+export interface DeployEvent {
+  id: string
+  status: ServiceStatus | string
+  /** e.g. `v12` or a short sha. */
+  ref?: string
+  source?: string
+  message?: string
+  /** Epoch **ms**. */
+  createdAt?: number
+}
+
+/** An environment option for the EnvSwitcher. */
+export interface EnvOption {
+  id: string
+  label: string
+  /** Optional count badge (e.g. services in this env). */
+  count?: number
+}
+
+/** An env var row for the Variables panel (secret-masked at the source). */
+export interface EnvVarRow {
+  key: string
+  value: string
+  secret?: boolean
+}
+
+/**
+ * Overridable status palette — semantic (status), NOT brand. Each status maps to
+ * a dot/text hue + a soft translucent chip background that reads in light and
+ * dark. Consumers may override per brand.
+ */
+export interface StatusPalette {
+  dot: string
+  fg: string
+  soft: string
+}

--- a/pkgs/canvas/tsconfig.json
+++ b/pkgs/canvas/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src", "gui.config.ts", "gui.d.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+}


### PR DESCRIPTION
New source-only `@hanzo/gui` package **`@hanzo/canvas`** — a Railway-grade project canvas that any Hanzo console (hanzo/lux/zoo) can reuse.

## What ships
A pannable/zoomable board of service nodes with live status and the honest connections between them:

- **`ProjectCanvas`** — pan/zoom board (React Flow): dot-grid, minimap, controls, deterministic layered auto-layout, theme-aware.
- **`ServiceNode`** — the layered service card: icon, name, type + `/v1` capability chip, status badge, source ref, replicas, latest-deploy time, and a metric sparkline preview. Elevated aesthetic (z-depth shadow, hover lift, selected ring).
- **`ServiceStatusBadge`** — status pill (dot + label) with a live pulse for active/deploying.
- **`MetricSparkline`** — honest tiny sparkline (flat baseline when there's no data — never a fabricated trend).
- **`DeployTimeline`** — vertical deploy/build timeline.
- **`EnvSwitcher`** — segmented environment switcher.
- **`ServiceDetailDrawer`** — right-side drawer with a service header + host-supplied tabs (Deployments/Variables/Metrics/Logs/Domains/SBOM).
- **`SourceRef`, `ReplicaPill`** — small primitives.
- Pure helpers: `normalizeServiceStatus`, `layoutGraph`, `relativeTime`, `toEpochMs`, `statusColors`, `withAlpha`, `kindLabel`.

## Principles
- **Decomplected**: every component is presentational and data-prop-driven (`./types`); the host owns data-fetching. Pure folds are unit-tested in isolation (17 tests).
- **Brand/white-label aware**: card chrome uses the neutral design tokens; status colors are semantic (not brand) and overridable per brand via `statusPalette`.
- **React-free logic** re-exported at `@hanzo/canvas/pure` so data mappers + tests never pull in JSX/`@xyflow/react`.

Consumed by hanzoai/console's App Platform + Map surfaces (separate PR). Published as `@hanzo/canvas@0.1.0`.

Verification: `tsc --noEmit` clean, `bun test` 17/17, `tsc` build emits `.d.ts`.

https://claude.ai/code/session_016yg7GPhYdWCh9vpp4HEwLZ