### PR TITLE
ci(release): pin npm@11 so the OIDC publish step runs on node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install NPM Dependencies
         run: pnpm install


### PR DESCRIPTION
After the owner-gate fix (#241), the Release job died at 'Update npm for OIDC support': npm install -g npm@latest now pulls npm@12, which requires node>=22, but the job pins node 20 -> EBADENGINE, exit 1, before changesets ever runs. npm 11.5.1+ has OIDC trusted-publishing AND supports node 20, so pin npm@11. Unblocks @hanzo/capture publish.