### PR TITLE
fix(pkgs/data): @hanzogui/config 7.2.2 -> 7.3.0 (unpublished pin breaks install)

### DIFF
--- a/pkgs/data/package.json
+++ b/pkgs/data/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@hanzo/gui": "7.2.2",
-    "@hanzogui/config": "7.2.2",
+    "@hanzogui/config": "7.3.0",
     "@types/react": "^19.1.10",
     "react": "^19.0.0",
     "typescript": "^5.7.2"


### PR DESCRIPTION
pkgs/data pinned @hanzogui/config@7.2.2 which was never published (latest 7.3.0); every sibling package already uses 7.3.0. This ERR_PNPM_NO_MATCHING_VERSION broke the whole monorepo pnpm install — including the Release job (blocking @hanzo/capture publish) and any other ui CI doing an install. One-line fix to the version its siblings use.