### PR TITLE
ci(release): publish path builds only @hanzo/capture (drop shadcn:build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       #   run: pnpm check
 
       - name: Build the package
-        run: pnpm shadcn:build
+        run: pnpm --filter=@hanzo/capture build
 
       - name: Create Version PR or Publish to NPM
         id: changesets


### PR DESCRIPTION
The Release Build step ran 'pnpm shadcn:build' (pnpm --filter=shadcn build), which OOMs building the whole shadcn workspace pkg — irrelevant to publishing @hanzo/capture, and an upstream-fork name we don't use. Build only the package being released: pnpm --filter=@hanzo/capture build.