### PR TITLE
fix(changeset): changelog repo -> hanzoai/ui (unblocks version/publish)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "shadcn-ui/ui" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "hanzoai/ui" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       #   run: pnpm check
 
       - name: Build the package
-        run: pnpm shadcn:build
+        run: pnpm --filter=@hanzo/capture build
 
       - name: Create Version PR or Publish to NPM
         id: changesets


### PR DESCRIPTION
changeset config pointed changelog-github at the upstream 'shadcn-ui/ui'; Hanzo commits don't exist there, so getInfo returns null -> 'Cannot read properties of null (reading author)' crashed 'changeset version'. Point it at hanzoai/ui.