### PR TITLE
ci(release): manual-only (stop churny auto-release)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "shadcn-ui/ui" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "hanzoai/ui" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@
 
 name: Release
 
+# Manual-only: publishing @hanzo/* needs npm auth for the scope (OIDC
+# trusted-publisher or NPM_TOKEN). Run from the Actions tab once that's set.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       #   run: pnpm check
 
       - name: Build the package
-        run: pnpm shadcn:build
+        run: pnpm --filter=@hanzo/capture build
 
       - name: Create Version PR or Publish to NPM
         id: changesets


### PR DESCRIPTION
The Release job auto-ran on every push and (absent @hanzo-scope npm auth) kept opening version PRs / failing publishes. Switch to workflow_dispatch so it only runs when intentionally triggered after npm auth is configured.